### PR TITLE
refactor: 代码简化与优化 — 消除重复、提取共享模式、改善可维护性

### DIFF
--- a/src/csmlogDocumentSymbolProvider.ts
+++ b/src/csmlogDocumentSymbolProvider.ts
@@ -75,11 +75,7 @@ export class CSMLogDocumentSymbolProvider implements vscode.DocumentSymbolProvid
             }
         }
 
-        // 按行号排序后统一构建 DocumentSymbol
-        entries.sort((a, b) => a.lineIndex - b.lineIndex);
-
-        // 最终排序后构建
-        entries.sort((a, b) => a.lineIndex - b.lineIndex);
+        // 循环已按行号递增顺序 push，entries 天然有序，直接构建即可
         return buildDocumentSymbols(document, entries);
     }
 }

--- a/src/csmlogHoverProvider.ts
+++ b/src/csmlogHoverProvider.ts
@@ -95,11 +95,10 @@ export class CSMLogHoverProvider implements vscode.HoverProvider {
             return undefined;
         }
 
-        // 2. File logger line (no event type)
+        // 2. File logger line (no event type) — 复用 parseLogLineZones 避免重复匹配时间戳
         if (RE_FILE_LOGGER.test(line)) {
-            // Only hover over the timestamp portion
-            const dateTsMatch = line.match(RE_DATE_TS);
-            if (dateTsMatch && col < dateTsMatch[0].length) {
+            const zones = parseLogLineZones(line);
+            if (zones?.dateTs && col < zones.dateTs[1]) {
                 return buildHover(db['__TIMESTAMP_DATE__']!);
             }
             return undefined;

--- a/src/hoverData/db.ts
+++ b/src/hoverData/db.ts
@@ -1,5 +1,5 @@
 import type { HoverEntry } from './types';
-import { localizeHoverEntries } from './localize';
+import { applyEnglishHoverTranslations } from './localize';
 import { isChineseLanguage } from '../i18n';
 import { operatorEntries } from './operators';
 import { commandEntries } from './commands';
@@ -38,7 +38,7 @@ export function getHoverDb(): Record<string, HoverEntry> {
     if (_hoverDbCache !== undefined && _hoverDbCache.isChinese === isChinese) {
         return _hoverDbCache.db;
     }
-    const db = localizeHoverEntries(zhHoverEntries, hoverTranslations);
+    const db = applyEnglishHoverTranslations(zhHoverEntries, hoverTranslations);
     _hoverDbCache = { isChinese, db };
     return db;
 }

--- a/src/hoverData/localize.ts
+++ b/src/hoverData/localize.ts
@@ -9,6 +9,12 @@ export function applyEnglishHoverTranslations(entries: Record<string, HoverEntry
 		return entries;
 	}
 
+	// 无翻译时跳过拷贝，直接返回原文
+	const translationKeys = Object.keys(translations);
+	if (translationKeys.length === 0) {
+		return entries;
+	}
+
 	const localized: Record<string, HoverEntry> = {};
 	for (const [key, entry] of Object.entries(entries)) {
 		localized[key] = translations[key] ?? entry;

--- a/src/hoverData/localize.ts
+++ b/src/hoverData/localize.ts
@@ -3,7 +3,8 @@ import type { HoverEntry } from './types';
 
 export type HoverTranslations = Partial<Record<string, HoverEntry>>;
 
-export function localizeHoverEntries(entries: Record<string, HoverEntry>, translations: HoverTranslations): Record<string, HoverEntry> {
+/** 非中文环境下将中文 hover 条目替换为英文翻译。中文环境下直接返回原文。 */
+export function applyEnglishHoverTranslations(entries: Record<string, HoverEntry>, translations: HoverTranslations): Record<string, HoverEntry> {
 	if (isChineseLanguage()) {
 		return entries;
 	}

--- a/src/hoverData/lookup.ts
+++ b/src/hoverData/lookup.ts
@@ -29,28 +29,25 @@ function lookupOperator(line: string, pos: number): HoverEntry | undefined {
         ['??',                        '??'],
     ];
     for (const [op, key] of candidates) {
-        // Check if the operator appears at or near pos
-        const start = Math.max(0, pos - op.length + 1);
-        const end = Math.min(line.length, pos + op.length);
-        const slice = line.substring(start, end);
-        if (slice.includes(op)) {
-            const idx = line.indexOf(op, Math.max(0, pos - op.length));
-            if (idx !== -1 && idx <= pos && pos < idx + op.length) {
-                return db[key];
-            }
+        const searchStart = Math.max(0, pos - op.length + 1);
+        const idx = line.indexOf(op, searchStart);
+        if (idx !== -1 && idx <= pos && pos < idx + op.length) {
+            return db[key];
         }
     }
     return undefined;
 }
 
+const WORD_CHAR = /[\w]/;
+
 /** Extract the word (identifier / command) around the cursor position. */
 function getWordAt(line: string, pos: number): string {
     // Expand left (include underscore, alphanumeric)
     let start = pos;
-    while (start > 0 && /[\w]/.test(line[start - 1])) { start--; }
+    while (start > 0 && WORD_CHAR.test(line[start - 1])) { start--; }
     // Expand right
     let end = pos;
-    while (end < line.length && /[\w]/.test(line[end])) { end++; }
+    while (end < line.length && WORD_CHAR.test(line[end])) { end++; }
     const base = line.substring(start, end);
 
     // If immediately followed by (...), include to handle WAIT(ms), RANDOM(INT), etc.

--- a/src/i18n.ts
+++ b/src/i18n.ts
@@ -12,6 +12,7 @@ export type LocalizedEntry = {
 export type LocalizedBundle = Record<string, LocalizedEntry>;
 
 let languageOverride: string | undefined;
+let _cachedLanguage: string | undefined;
 
 function getLanguageFromNlsConfig(): string | undefined {
 	const rawConfig = process.env.VSCODE_NLS_CONFIG;
@@ -30,15 +31,22 @@ function getLanguageFromNlsConfig(): string | undefined {
 }
 
 function getCurrentLanguage(): string {
+	// override（测试用）始终优先，不使用缓存
 	if (languageOverride) {
 		return languageOverride;
 	}
 
-	if (typeof vscode.env?.language === 'string' && vscode.env.language.trim().length > 0) {
-		return vscode.env.language;
+	if (_cachedLanguage !== undefined) {
+		return _cachedLanguage;
 	}
 
-	return getLanguageFromNlsConfig() ?? 'en';
+	if (typeof vscode.env?.language === 'string' && vscode.env.language.trim().length > 0) {
+		_cachedLanguage = vscode.env.language;
+		return _cachedLanguage;
+	}
+
+	_cachedLanguage = getLanguageFromNlsConfig() ?? 'en';
+	return _cachedLanguage;
 }
 
 export function isChineseLanguage(): boolean {
@@ -68,4 +76,5 @@ export function localizeBundle<Bundle extends LocalizedBundle, Key extends keyof
 
 export function __setLanguageOverrideForTests(language: string | undefined): void {
 	languageOverride = language;
+	_cachedLanguage = undefined; // 使缓存失效，下次调用重新检测
 }

--- a/src/moduleManager/labviewVersionDetector.ts
+++ b/src/moduleManager/labviewVersionDetector.ts
@@ -89,17 +89,15 @@ function bcdDecode(hexByte: number): number {
     return ((hexByte >> 4) * 10) + (hexByte & 0x0F);
 }
 
-/**
- * 将 LVVersion 编码字符串解码为可读版本。
- * 优先查表，查不到则尝试根据编码规则推算。
- */
-export function decodeLvVersion(lvVersionHex: string): string | undefined {
-    const key = lvVersionHex.toUpperCase();
-    if (LV_VERSION_MAP[key]) {
-        return LV_VERSION_MAP[key];
-    }
+interface LvVersionFields {
+    yy: number;
+    mm: number;
+    is64Bit: boolean;
+}
 
-    // 尝试根据编码规则推算
+/** 从 LVVersion 十六进制编码中解析出主版本、次版本和 64 位标志。 */
+function parseLvVersionFields(lvVersionHex: string): LvVersionFields | undefined {
+    const key = lvVersionHex.toUpperCase();
     if (!/^[0-9a-fA-F]{8}$/.test(lvVersionHex)) {
         return undefined;
     }
@@ -112,6 +110,23 @@ export function decodeLvVersion(lvVersionHex: string): string | undefined {
         return undefined;
     }
 
+    return { yy, mm, is64Bit };
+}
+
+/**
+ * 将 LVVersion 编码字符串解码为可读版本。
+ * 优先查表，查不到则尝试根据编码规则推算。
+ */
+export function decodeLvVersion(lvVersionHex: string): string | undefined {
+    const key = lvVersionHex.toUpperCase();
+    if (LV_VERSION_MAP[key]) {
+        return LV_VERSION_MAP[key];
+    }
+
+    const fields = parseLvVersionFields(lvVersionHex);
+    if (!fields) { return undefined; }
+
+    const { yy, mm, is64Bit } = fields;
     const yearLabel = yy <= 8 ? `${yy}` : `20${yy.toString().padStart(2, '0')}`;
     const minorLabel = mm > 0 ? `.${mm}` : '';
     const bitLabel = is64Bit ? ' (64-bit)' : '';
@@ -128,19 +143,10 @@ export function getLvVersionDisplay(lvVersionHex: string): string | undefined {
         return LV_DISPLAY_MAP[key];
     }
 
-    // 根据编码规则推算
-    if (!/^[0-9a-fA-F]{8}$/.test(lvVersionHex)) {
-        return undefined;
-    }
+    const fields = parseLvVersionFields(lvVersionHex);
+    if (!fields) { return undefined; }
 
-    const yy = bcdDecode(parseInt(key.substring(0, 2), 16));
-    const mm = bcdDecode(parseInt(key.substring(2, 4), 16));
-    const is64Bit = (parseInt(key.substring(6, 8), 16) & 0x40) !== 0;
-
-    if (yy < 8 || yy > 99) {
-        return undefined;
-    }
-
+    const { yy, mm, is64Bit } = fields;
     let display: string;
     if (yy <= 9) {
         display = `lv${yy}.${mm}`;

--- a/src/moduleManager/labviewVersionDetector.ts
+++ b/src/moduleManager/labviewVersionDetector.ts
@@ -294,110 +294,64 @@ async function findFirstFile(dirPath: string, pattern: RegExp): Promise<string |
 }
 
 /**
+ * 从 startDir 向上遍历祖先目录，对每个目录调用 visitor 直到返回非 undefined 值。
+ * 用于实现"查找最近的匹配文件"模式。
+ */
+async function walkUpAncestors<T>(
+    startDir: string,
+    visitor: (dir: string) => Promise<T | undefined>,
+): Promise<T | undefined> {
+    let currentDir = path.resolve(startDir);
+    const root = path.parse(currentDir).root;
+    while (true) {
+        const result = await visitor(currentDir);
+        if (result !== undefined) { return result; }
+        if (currentDir === root) { break; }
+        const parent = path.dirname(currentDir);
+        if (parent === currentDir) { break; }
+        currentDir = parent;
+    }
+    return undefined;
+}
+
+/**
  * 从当前目录向上遍历祖先目录，查找"DEV ENVIRONMENT"标记文件。
  * 返回距离当前目录最近的匹配结果。
  */
 async function findDevEnvironmentFile(moduleDirPath: string): Promise<string | undefined> {
-    let currentDir = path.resolve(moduleDirPath);
-    const root = path.parse(currentDir).root;
-
-    while (currentDir !== root) {
-        const result = await findFirstFile(currentDir, /^DEV ENVIRONMENT/i);
-        if (result) {
-            return result;
-        }
-        const parent = path.dirname(currentDir);
-        if (parent === currentDir) {
-            break;
-        }
-        currentDir = parent;
-    }
-
-    // 检查根目录
-    const rootResult = await findFirstFile(root, /^DEV ENVIRONMENT/i);
-    return rootResult;
+    return walkUpAncestors(moduleDirPath, (dir) => findFirstFile(dir, /^DEV ENVIRONMENT/i));
 }
 
 /**
  * 从当前目录向上遍历，查找最近的 .lvproj 文件并提取 LVVersion。
  */
 async function findLvprojVersion(moduleDirPath: string): Promise<string | undefined> {
-    let currentDir = path.resolve(moduleDirPath);
-    const root = path.parse(currentDir).root;
-
-    while (currentDir !== root) {
-        const lvprojPath = await findFirstFile(currentDir, /\.lvproj$/i);
-        if (lvprojPath) {
-            try {
-                const content = await fs.readFile(lvprojPath, 'utf-8');
-                const version = extractLvVersionFromXml(content);
-                if (version) {
-                    return version;
-                }
-            } catch {
-                // 读取失败，继续向上查找
-            }
-        }
-        const parent = path.dirname(currentDir);
-        if (parent === currentDir) {
-            break;
-        }
-        currentDir = parent;
-    }
-
-    // 检查根目录
-    const rootLvproj = await findFirstFile(root, /\.lvproj$/i);
-    if (rootLvproj) {
+    return walkUpAncestors(moduleDirPath, async (dir) => {
+        const lvprojPath = await findFirstFile(dir, /\.lvproj$/i);
+        if (!lvprojPath) { return undefined; }
         try {
-            const content = await fs.readFile(rootLvproj, 'utf-8');
+            const content = await fs.readFile(lvprojPath, 'utf-8');
             return extractLvVersionFromXml(content);
         } catch {
-            // 忽略
+            return undefined;
         }
-    }
-
-    return undefined;
+    });
 }
 
 /**
  * 从当前目录向上遍历，查找最近的 .lvlib 文件并提取 LVVersion。
  */
 async function findLvlibVersion(moduleDirPath: string): Promise<string | undefined> {
-    let currentDir = path.resolve(moduleDirPath);
-    const root = path.parse(currentDir).root;
-
-    while (currentDir !== root) {
-        const lvlibPath = await findFirstFile(currentDir, /\.lvlib$/i);
-        if (lvlibPath) {
-            try {
-                const content = await fs.readFile(lvlibPath, 'utf-8');
-                const version = extractLvVersionFromXml(content);
-                if (version) {
-                    return version;
-                }
-            } catch {
-                // 读取失败，继续向上查找
-            }
-        }
-        const parent = path.dirname(currentDir);
-        if (parent === currentDir) {
-            break;
-        }
-        currentDir = parent;
-    }
-
-    // 检查根目录
-    const rootLvlib = await findFirstFile(root, /\.lvlib$/i);
-    if (rootLvlib) {
+    return walkUpAncestors(moduleDirPath, async (dir) => {
+        const lvlibPath = await findFirstFile(dir, /\.lvlib$/i);
+        if (!lvlibPath) { return undefined; }
         try {
-            const content = await fs.readFile(rootLvlib, 'utf-8');
+            const content = await fs.readFile(lvlibPath, 'utf-8');
             return extractLvVersionFromXml(content);
         } catch {
-            // 忽略
+            return undefined;
         }
-    }
-
-    return undefined;
+    });
 }
 
 /**

--- a/src/moduleManager/labviewVersionDetector.ts
+++ b/src/moduleManager/labviewVersionDetector.ts
@@ -162,36 +162,38 @@ export function getLvVersionDisplay(lvVersionHex: string): string | undefined {
  *   "DEV ENVIRONMENT LabVIEW 2020"      → "lv2020"
  *   "DEV ENVIRONMENT LabVIEW 2020(64bit)" → "lv2020(64bit)"
  */
+function formatLvDisplay(version: string, is64Bit: boolean): string {
+    return `lv${version}${is64Bit ? '(64bit)' : ''}`;
+}
+
 export function parseDevEnvironmentFileName(fileName: string): string | undefined {
     if (!fileName.startsWith(DEV_ENV_PREFIX)) {
         return undefined;
     }
 
     const suffix = fileName.slice(DEV_ENV_PREFIX.length).trim();
+    let version: string | undefined;
+    let is64Bit = false;
 
     // 匹配 "LabVIEW XXXX" 或 "LabVIEW XXXX(64bit)"
     const match = suffix.match(/^LabVIEW\s+(\d+(?:\.\d+)?)(?:\((\d+)bit\))?$/i);
-    if (!match) {
+    if (match) {
+        version = match[1];
+        is64Bit = match[2] === '64';
+    } else {
         // 宽松匹配：尝试提取版本号
         const looseMatch = suffix.match(/(\d+(?:\.\d+)?)/);
         if (!looseMatch) {
             return undefined;
         }
-        const version = looseMatch[1];
-        const is64Bit = /64\s*bit/i.test(suffix);
-        if (version.includes('.')) {
-            return `lv${version}${is64Bit ? '(64bit)' : ''}`;
-        }
-        return `lv${version}${is64Bit ? '(64bit)' : ''}`;
+        version = looseMatch[1];
+        is64Bit = /64\s*bit/i.test(suffix);
     }
 
-    const version = match[1];
-    const is64Bit = match[2] === '64';
-
-    if (version.includes('.')) {
-        return `lv${version}${is64Bit ? '(64bit)' : ''}`;
+    if (!version) {
+        return undefined;
     }
-    return `lv${version}${is64Bit ? '(64bit)' : ''}`;
+    return formatLvDisplay(version, is64Bit);
 }
 
 /**

--- a/src/moduleManager/moduleManagerController.ts
+++ b/src/moduleManager/moduleManagerController.ts
@@ -179,29 +179,37 @@ export class ModuleManagerController {
 		};
 	}
 
+	private registerCommand<T extends unknown[]>(
+		subscriptions: vscode.Disposable[],
+		commandId: string,
+		handler: (...args: T) => Promise<void> | void,
+	): void {
+		subscriptions.push(
+			vscode.commands.registerCommand(commandId, wrapCommand(commandId, handler, this.logger)),
+		);
+	}
+
 	public register(subscriptions: vscode.Disposable[]): void {
 		subscriptions.push(vscode.window.registerWebviewViewProvider(VIEW_IDS.moduleSidebar, this.sidebarViewProvider, {
 			webviewOptions: { retainContextWhenHidden: true },
 		}));
 
-		subscriptions.push(
-			vscode.commands.registerCommand(COMMAND_IDS.login, wrapCommand(COMMAND_IDS.login, () => this.loginCommand(), this.logger)),
-			vscode.commands.registerCommand(COMMAND_IDS.logout, wrapCommand(COMMAND_IDS.logout, () => this.logoutCommand(), this.logger)),
-			vscode.commands.registerCommand(COMMAND_IDS.refresh, wrapCommand(COMMAND_IDS.refresh, () => this.refreshCommand(), this.logger)),
-			vscode.commands.registerCommand(COMMAND_IDS.initializeWorkspace, wrapCommand(COMMAND_IDS.initializeWorkspace, () => this.initializeWorkspaceCommand(), this.logger)),
-			vscode.commands.registerCommand(COMMAND_IDS.openReadme, wrapCommand(COMMAND_IDS.openReadme, (entry?: CsmModuleEntry | ModuleTreeItem) => this.openReadmeCommand(entry), this.logger)),
-			vscode.commands.registerCommand(COMMAND_IDS.applyToWorkspace, wrapCommand(COMMAND_IDS.applyToWorkspace, (entry?: CsmModuleEntry | ModuleTreeItem) => this.applyToWorkspaceCommand(entry), this.logger)),
-			vscode.commands.registerCommand(COMMAND_IDS.removeModule, wrapCommand(COMMAND_IDS.removeModule, (entry?: CsmModuleEntry | ModuleTreeItem) => this.removeModuleCommand(entry), this.logger)),
-			vscode.commands.registerCommand(COMMAND_IDS.updateModule, wrapCommand(COMMAND_IDS.updateModule, (entry?: CsmModuleEntry | ModuleTreeItem) => this.updateModuleCommand(entry), this.logger)),
-			vscode.commands.registerCommand(COMMAND_IDS.contextApplyModule, wrapCommand(COMMAND_IDS.contextApplyModule, (context?: WebviewModuleContext) => this.contextApplyModuleCommand(context), this.logger)),
-			vscode.commands.registerCommand(COMMAND_IDS.contextOpenReadme, wrapCommand(COMMAND_IDS.contextOpenReadme, (context?: WebviewModuleContext) => this.contextOpenReadmeCommand(context), this.logger)),
-			vscode.commands.registerCommand(COMMAND_IDS.contextRemoveModule, wrapCommand(COMMAND_IDS.contextRemoveModule, (context?: WebviewModuleContext) => this.contextRemoveModuleCommand(context), this.logger)),
-			vscode.commands.registerCommand(COMMAND_IDS.contextUpdateModule, wrapCommand(COMMAND_IDS.contextUpdateModule, (context?: WebviewModuleContext) => this.contextUpdateModuleCommand(context), this.logger)),
-			vscode.commands.registerCommand(COMMAND_IDS.contextSelectModule, wrapCommand(COMMAND_IDS.contextSelectModule, (context?: WebviewModuleContext) => this.contextSelectModuleCommand(context), this.logger)),
-			vscode.commands.registerCommand(COMMAND_IDS.contextClearModuleSelection, wrapCommand(COMMAND_IDS.contextClearModuleSelection, (context?: WebviewModuleContext) => this.contextClearModuleSelectionCommand(context), this.logger)),
-			vscode.commands.registerCommand(COMMAND_IDS.contextOpenFolder, wrapCommand(COMMAND_IDS.contextOpenFolder, (context?: WebviewModuleContext) => this.contextOpenFolderCommand(context), this.logger)),
-			vscode.commands.registerCommand(COMMAND_IDS.setSortOrder, wrapCommand(COMMAND_IDS.setSortOrder, (field?: ModuleSortField) => this.setSortOrderCommand(field), this.logger)),
-		);
+		this.registerCommand(subscriptions, COMMAND_IDS.login, () => this.loginCommand());
+		this.registerCommand(subscriptions, COMMAND_IDS.logout, () => this.logoutCommand());
+		this.registerCommand(subscriptions, COMMAND_IDS.refresh, () => this.refreshCommand());
+		this.registerCommand(subscriptions, COMMAND_IDS.initializeWorkspace, () => this.initializeWorkspaceCommand());
+		this.registerCommand(subscriptions, COMMAND_IDS.openReadme, (entry?: CsmModuleEntry | ModuleTreeItem) => this.openReadmeCommand(entry));
+		this.registerCommand(subscriptions, COMMAND_IDS.applyToWorkspace, (entry?: CsmModuleEntry | ModuleTreeItem) => this.applyToWorkspaceCommand(entry));
+		this.registerCommand(subscriptions, COMMAND_IDS.removeModule, (entry?: CsmModuleEntry | ModuleTreeItem) => this.removeModuleCommand(entry));
+		this.registerCommand(subscriptions, COMMAND_IDS.updateModule, (entry?: CsmModuleEntry | ModuleTreeItem) => this.updateModuleCommand(entry));
+		this.registerCommand(subscriptions, COMMAND_IDS.contextApplyModule, (context?: WebviewModuleContext) => this.contextApplyModuleCommand(context));
+		this.registerCommand(subscriptions, COMMAND_IDS.contextOpenReadme, (context?: WebviewModuleContext) => this.contextOpenReadmeCommand(context));
+		this.registerCommand(subscriptions, COMMAND_IDS.contextRemoveModule, (context?: WebviewModuleContext) => this.contextRemoveModuleCommand(context));
+		this.registerCommand(subscriptions, COMMAND_IDS.contextUpdateModule, (context?: WebviewModuleContext) => this.contextUpdateModuleCommand(context));
+		this.registerCommand(subscriptions, COMMAND_IDS.contextSelectModule, (context?: WebviewModuleContext) => this.contextSelectModuleCommand(context));
+		this.registerCommand(subscriptions, COMMAND_IDS.contextClearModuleSelection, (context?: WebviewModuleContext) => this.contextClearModuleSelectionCommand(context));
+		this.registerCommand(subscriptions, COMMAND_IDS.contextOpenFolder, (context?: WebviewModuleContext) => this.contextOpenFolderCommand(context));
+		this.registerCommand(subscriptions, COMMAND_IDS.setSortOrder, (field?: ModuleSortField) => this.setSortOrderCommand(field));
 
 		// 延迟读取缓存快照，让 Webview 先渲染骨架屏，提升启动感知速度
 		// 使用微任务而非 setTimeout，确保测试中 await Promise.resolve() 能 flush

--- a/src/moduleManager/moduleSidebarHtml.ts
+++ b/src/moduleManager/moduleSidebarHtml.ts
@@ -1,6 +1,7 @@
 import * as crypto from 'crypto';
 import { ModuleListScope, ModuleSortDirection, ModuleSortField, ModuleSortState } from './interfaces';
 import { getApplyMethodLabel, getHtmlLang, getVisibilityLabel, t } from './messages';
+import { truncate } from './utils';
 import { ViewState } from './moduleTreeTypes';
 import { sortModules } from './sort';
 import { getVisibleModuleTopics } from './topics';
@@ -35,13 +36,6 @@ export interface ModuleSidebarRenderState extends LocalWorkspaceRenderState {
 	renderLimit: number;
 	initialRenderLimit: number;
 	webviewCspSource?: string;
-}
-
-function truncate(text: string, maxLength: number): string {
-	if (text.length <= maxLength) {
-		return text;
-	}
-	return `${text.slice(0, maxLength - 3)}...`;
 }
 
 function escapeHtml(value: string): string {

--- a/src/moduleManager/moduleSidebarViewProvider.ts
+++ b/src/moduleManager/moduleSidebarViewProvider.ts
@@ -5,6 +5,7 @@ import { IModuleViewProvider, ModuleListScope, ModuleSortDirection, ModuleSortFi
 import { DEFAULT_MODULE_SORT_STATE, isModuleSortDirection, isModuleSortField, normalizeModuleSortState } from './sort';
 import { t } from './messages';
 import { renderModuleSidebarHtml } from './moduleSidebarHtml';
+import { getModuleKey } from './utils';
 
 interface ModuleSidebarActions {
 	onLogin: () => void;
@@ -78,7 +79,7 @@ export class ModuleSidebarViewProvider implements vscode.WebviewViewProvider, IM
 	) { }
 
 	public static getModuleKey(entry: CsmModuleEntry): string {
-		return `${entry.owner}/${entry.name}`;
+		return getModuleKey(entry);
 	}
 
 	public resolveWebviewView(
@@ -215,181 +216,91 @@ export class ModuleSidebarViewProvider implements vscode.WebviewViewProvider, IM
 		this.render();
 	}
 
-	private async handleMessage(message: unknown): Promise<void> {
-		if (!this.isWebviewMessage(message)) {
-			return;
-		}
+	// 消息类型 → 处理函数的声明式映射（替代 switch-case）
+	private readonly messageHandlers: Record<string, (msg: WebviewMessage) => void> = {
+		login: () => this.actions.onLogin(),
+		refresh: () => this.actions.onRefresh(),
+		initializeWorkspace: () => this.actions.onInitializeWorkspace(),
+		applySelected: () => this.actions.onApplySelection(),
+		setFilterQuery: (msg) => { this.filterQuery = typeof msg.query === 'string' ? msg.query.slice(0, 120) : ''; },
+		clearFilter: () => { this.filterQuery = ''; },
+		setIncludeApplied: (msg) => { this.includeAppliedModules = msg.includeApplied === true; this.render(); },
+		setScope: (msg) => {
+			if (msg.scope === 'all' || msg.scope === 'workspace' || msg.scope === 'catalog') {
+				this.scope = msg.scope;
+				this.render();
+			}
+		},
+		setSortField: (msg) => {
+			if (isModuleSortField(msg.sortField)) {
+				this.actions.onSortChange({ field: msg.sortField });
+			}
+		},
+		setSortDirection: (msg) => {
+			if (isModuleSortDirection(msg.sortDirection)) {
+				this.actions.onSortChange({ direction: msg.sortDirection });
+			}
+		},
+		dismissIntroTip: () => { this.introTipVisible = false; this.render(); },
+		showMore: () => { this.renderLimit += ModuleSidebarViewProvider.INITIAL_RENDER_LIMIT; this.render(); },
 
-		switch (message.type) {
-			case 'login':
-				this.actions.onLogin();
-				return;
-			case 'refresh':
-				this.actions.onRefresh();
-				return;
-			case 'initializeWorkspace':
-				this.actions.onInitializeWorkspace();
-				return;
-			case 'toggleStar': {
-				const entry = message.moduleKey ? this.findEntry(message.moduleKey) : undefined;
-				if (entry) {
-					this.actions.onToggleStar(entry);
-				}
-				return;
+		// moduleKey 查找 → 动作分发
+		toggleStar: (msg) => this.withModuleEntry(msg, (e) => this.actions.onToggleStar(e)),
+		openReadme: (msg) => this.withModuleEntry(msg, (e) => this.actions.onOpenReadme(e)),
+		openRepository: (msg) => this.withModuleEntry(msg, (e) => this.actions.onOpenRepository?.(e)),
+		togglePreview: (msg) => this.withModuleEntry(msg, (e) => this.actions.onOpenReadme(e)),
+		applyOne: (msg) => this.withModuleEntry(msg, (e) => this.actions.onApplySelection(e)),
+		removeModule: (msg) => this.withModuleEntry(msg, (e) => this.actions.onRemoveModule(e)),
+		updateModule: (msg) => this.withModuleEntry(msg, (e) => this.actions.onUpdateModule(e)),
+
+		// 选择状态
+		toggleSelection: (msg) => {
+			if (!msg.moduleKey) { return; }
+			if (msg.selected) {
+				this.selectedModuleKeys.add(msg.moduleKey);
+			} else {
+				this.selectedModuleKeys.delete(msg.moduleKey);
 			}
-			case 'applySelected':
-				this.actions.onApplySelection();
-				return;
-			case 'setFilterQuery':
-				this.filterQuery = typeof message.query === 'string' ? message.query.slice(0, 120) : '';
-				return;
-			case 'clearFilter':
-				this.filterQuery = '';
-				return;
-			case 'setIncludeApplied':
-				this.includeAppliedModules = message.includeApplied === true;
-				this.render();
-				return;
-			case 'setScope':
-				if (message.scope === 'all' || message.scope === 'workspace' || message.scope === 'catalog') {
-					this.scope = message.scope;
-					this.render();
-				}
-				return;
-			case 'setSortField':
-				if (isModuleSortField(message.sortField)) {
-					this.actions.onSortChange({ field: message.sortField });
-				}
-				return;
-			case 'setSortDirection':
-				if (isModuleSortDirection(message.sortDirection)) {
-					this.actions.onSortChange({ direction: message.sortDirection });
-				}
-				return;
-			case 'dismissIntroTip':
-				this.introTipVisible = false;
-				this.render();
-				return;
-			case 'toggleSelection': {
-				if (!message.moduleKey) {
-					return;
-				}
-				if (message.selected) {
-					this.selectedModuleKeys.add(message.moduleKey);
-				} else {
-					this.selectedModuleKeys.delete(message.moduleKey);
-				}
-				this.pruneSelection();
-				this.render();
-				this.actions.onSelectionChange([...this.selectedModuleKeys]);
-				return;
-			}
-			case 'openReadme': {
-				const entry = message.moduleKey ? this.findEntry(message.moduleKey) : undefined;
-				if (entry) {
-					this.actions.onOpenReadme(entry);
-				}
-				return;
-			}
-			case 'openRepository': {
-				const entry = message.moduleKey ? this.findEntry(message.moduleKey) : undefined;
-				if (entry) {
-					this.actions.onOpenRepository?.(entry);
-				}
-				return;
-			}
-			case 'togglePreview': {
-				const entry = message.moduleKey ? this.findEntry(message.moduleKey) : undefined;
-				if (entry) {
-					this.actions.onOpenReadme(entry);
-				}
-				return;
-			}
-			case 'applyOne': {
-				const entry = message.moduleKey ? this.findEntry(message.moduleKey) : undefined;
-				if (entry) {
-					this.actions.onApplySelection(entry);
-				}
-				return;
-			}
-			case 'removeModule': {
-				const entry = message.moduleKey ? this.findEntry(message.moduleKey) : undefined;
-				if (entry) {
-					this.actions.onRemoveModule(entry);
-				}
-				return;
-			}
-			case 'updateModule': {
-				const entry = message.moduleKey ? this.findEntry(message.moduleKey) : undefined;
-				if (entry) {
-					this.actions.onUpdateModule(entry);
-				}
-				return;
-			}
-			case 'openLocalReadme': {
-				const entry = message.localItemId ? this.localManagedModulesById.get(message.localItemId) : undefined;
-				if (entry) {
-					this.actions.onOpenReadme(entry.moduleEntry);
-				}
-				return;
-			}
-			case 'openLocalFolder': {
-				const managed = message.localItemId ? this.localManagedModulesById.get(message.localItemId) : undefined;
-				const unmanaged = message.localItemId ? this.localUnmanagedFoldersById.get(message.localItemId) : undefined;
-				const folderEntry = managed ?? unmanaged;
-				if (folderEntry) {
-					this.actions.onOpenLocalFolder?.(folderEntry);
-				}
-				return;
-			}
-			case 'removeLocalModule': {
-				const entry = message.localItemId ? this.localManagedModulesById.get(message.localItemId) : undefined;
-				if (entry) {
-					this.actions.onRemoveModule(entry.moduleEntry);
-				}
-				return;
-			}
-			case 'updateLocalModule': {
-				const entry = message.localItemId ? this.localManagedModulesById.get(message.localItemId) : undefined;
-				if (entry) {
-					this.actions.onUpdateModule(entry.moduleEntry);
-				}
-				return;
-			}
-			case 'toggleLocalModuleLock': {
-				const entry = message.localItemId ? this.localManagedModulesById.get(message.localItemId) : undefined;
-				if (entry) {
-					this.actions.onToggleLocalModuleLock?.(entry);
-				}
-				return;
-			}
-			case 'switchLocalModuleMethod': {
-				const entry = message.localItemId ? this.localManagedModulesById.get(message.localItemId) : undefined;
-				if (entry) {
-					this.actions.onSwitchLocalModuleMethod?.(entry);
-				}
-				return;
-			}
-			case 'createLocalRepository': {
-				const entry = message.localItemId ? this.localUnmanagedFoldersById.get(message.localItemId) : undefined;
-				if (entry) {
-					this.actions.onCreateLocalRepository?.(entry);
-				}
-				return;
-			}
-			case 'linkLocalRepository': {
-				const entry = message.localItemId ? this.localUnmanagedFoldersById.get(message.localItemId) : undefined;
-				if (entry) {
-					this.actions.onLinkLocalRepository?.(entry);
-				}
-				return;
-			}
-			case 'showMore': {
-				this.renderLimit += ModuleSidebarViewProvider.INITIAL_RENDER_LIMIT;
-				this.render();
-				return;
-			}
-		}
+			this.pruneSelection();
+			this.render();
+			this.actions.onSelectionChange([...this.selectedModuleKeys]);
+		},
+
+		// localItemId 查找 → 动作分发
+		openLocalReadme: (msg) => this.withLocalManagedEntry(msg, (e) => this.actions.onOpenReadme(e.moduleEntry)),
+		removeLocalModule: (msg) => this.withLocalManagedEntry(msg, (e) => this.actions.onRemoveModule(e.moduleEntry)),
+		updateLocalModule: (msg) => this.withLocalManagedEntry(msg, (e) => this.actions.onUpdateModule(e.moduleEntry)),
+		toggleLocalModuleLock: (msg) => this.withLocalManagedEntry(msg, (e) => this.actions.onToggleLocalModuleLock?.(e)),
+		switchLocalModuleMethod: (msg) => this.withLocalManagedEntry(msg, (e) => this.actions.onSwitchLocalModuleMethod?.(e)),
+		createLocalRepository: (msg) => this.withLocalUnmanagedEntry(msg, (e) => this.actions.onCreateLocalRepository?.(e)),
+		linkLocalRepository: (msg) => this.withLocalUnmanagedEntry(msg, (e) => this.actions.onLinkLocalRepository?.(e)),
+
+		openLocalFolder: (msg) => {
+			const managed = msg.localItemId ? this.localManagedModulesById.get(msg.localItemId) : undefined;
+			const unmanaged = msg.localItemId ? this.localUnmanagedFoldersById.get(msg.localItemId) : undefined;
+			const folderEntry = managed ?? unmanaged;
+			if (folderEntry) { this.actions.onOpenLocalFolder?.(folderEntry); }
+		},
+	};
+
+	private withModuleEntry(msg: WebviewMessage, action: (entry: CsmModuleEntry) => void): void {
+		const entry = msg.moduleKey ? this.findEntry(msg.moduleKey) : undefined;
+		if (entry) { action(entry); }
+	}
+
+	private withLocalManagedEntry(msg: WebviewMessage, action: (entry: LocalManagedModuleEntry) => void): void {
+		const entry = msg.localItemId ? this.localManagedModulesById.get(msg.localItemId) : undefined;
+		if (entry) { action(entry); }
+	}
+
+	private withLocalUnmanagedEntry(msg: WebviewMessage, action: (entry: LocalUnmanagedFolderEntry) => void): void {
+		const entry = msg.localItemId ? this.localUnmanagedFoldersById.get(msg.localItemId) : undefined;
+		if (entry) { action(entry); }
+	}
+
+	private async handleMessage(message: unknown): Promise<void> {
+		if (!this.isWebviewMessage(message)) { return; }
+		this.messageHandlers[message.type]?.(message);
 	}
 
 	private isWebviewMessage(message: unknown): message is WebviewMessage {
@@ -397,11 +308,11 @@ export class ModuleSidebarViewProvider implements vscode.WebviewViewProvider, IM
 	}
 
 	private findEntry(moduleKey: string): CsmModuleEntry | undefined {
-		return this.modules.find((entry) => ModuleSidebarViewProvider.getModuleKey(entry) === moduleKey);
+		return this.modules.find((entry) => getModuleKey(entry) === moduleKey);
 	}
 
 	private pruneSelection(): void {
-		const availableKeys = new Set(this.modules.map((entry) => ModuleSidebarViewProvider.getModuleKey(entry)));
+		const availableKeys = new Set(this.modules.map((entry) => getModuleKey(entry)));
 		for (const key of [...this.selectedModuleKeys]) {
 			if (!availableKeys.has(key)) {
 				this.selectedModuleKeys.delete(key);

--- a/src/moduleManager/moduleSidebarViewProvider.ts
+++ b/src/moduleManager/moduleSidebarViewProvider.ts
@@ -185,25 +185,27 @@ export class ModuleSidebarViewProvider implements vscode.WebviewViewProvider, IM
 		this.gitAvailable = context.gitAvailable === true;
 		this.localManagedModules = context.managedModules ?? [];
 		this.localUnmanagedFolders = context.unmanagedFolders ?? [];
-		this.localManagedModulesById.clear();
-		for (const entry of this.localManagedModules) {
-			this.localManagedModulesById.set(entry.id, entry);
+		this.rebuildMap(this.localManagedModulesById, this.localManagedModules, (e) => e.id);
+		this.rebuildMap(this.localUnmanagedFoldersById, this.localUnmanagedFolders, (e) => e.id);
+		this.rebuildSet(this.appliedModuleKeys, context.appliedModuleKeys, (k) => this.findEntry(k) !== undefined);
+		this.rebuildSet(this.staleModuleKeys, context.staleModuleKeys ?? []);
+		this.render();
+	}
+
+	private rebuildMap<K, V>(map: Map<K, V>, items: V[], keyFn: (item: V) => K): void {
+		map.clear();
+		for (const item of items) {
+			map.set(keyFn(item), item);
 		}
-		this.localUnmanagedFoldersById.clear();
-		for (const entry of this.localUnmanagedFolders) {
-			this.localUnmanagedFoldersById.set(entry.id, entry);
-		}
-		this.appliedModuleKeys.clear();
-		for (const moduleKey of context.appliedModuleKeys) {
-			if (this.findEntry(moduleKey)) {
-				this.appliedModuleKeys.add(moduleKey);
+	}
+
+	private rebuildSet<T>(set: Set<T>, items: Iterable<T>, filter?: (item: T) => boolean): void {
+		set.clear();
+		for (const item of items) {
+			if (!filter || filter(item)) {
+				set.add(item);
 			}
 		}
-		this.staleModuleKeys.clear();
-		for (const key of context.staleModuleKeys ?? []) {
-			this.staleModuleKeys.add(key);
-		}
-		this.render();
 	}
 
 	public setOfflineMode(offline: boolean): void {

--- a/src/moduleManager/moduleSidebarViewProvider.ts
+++ b/src/moduleManager/moduleSidebarViewProvider.ts
@@ -302,7 +302,14 @@ export class ModuleSidebarViewProvider implements vscode.WebviewViewProvider, IM
 
 	private async handleMessage(message: unknown): Promise<void> {
 		if (!this.isWebviewMessage(message)) { return; }
-		this.messageHandlers[message.type]?.(message);
+
+		const handler = Object.prototype.hasOwnProperty.call(this.messageHandlers, message.type)
+			? this.messageHandlers[message.type]
+			: undefined;
+
+		if (typeof handler === 'function') {
+			handler(message);
+		}
 	}
 
 	private isWebviewMessage(message: unknown): message is WebviewMessage {

--- a/src/moduleManager/moduleTreeTypes.ts
+++ b/src/moduleManager/moduleTreeTypes.ts
@@ -6,15 +6,9 @@ import * as vscode from 'vscode';
 import { CsmModuleEntry } from './types';
 import { getVisibilityLabel, getVisibilityTag, t } from './messages';
 import { getVisibleModuleTopics } from './topics';
+import { truncate } from './utils';
 
 export type ViewState = 'loading' | 'ready' | 'empty' | 'error';
-
-function truncate(text: string, maxLength: number): string {
-    if (text.length <= maxLength) {
-        return text;
-    }
-    return `${text.slice(0, maxLength - 3)}...`;
-}
 
 /**
  * 树视图中表示一个 CSM 模块的 TreeItem。

--- a/src/moduleManager/sort.ts
+++ b/src/moduleManager/sort.ts
@@ -1,5 +1,6 @@
 import { ModuleSortDirection, ModuleSortField, ModuleSortState } from './interfaces';
 import { CsmModuleEntry } from './types';
+import { getModuleKey } from './utils';
 
 export const MODULE_SORT_FIELDS: readonly ModuleSortField[] = ['name', 'owner', 'updatedAt', 'applied'];
 export const MODULE_SORT_DIRECTIONS: readonly ModuleSortDirection[] = ['asc', 'desc'];
@@ -115,6 +116,3 @@ function applyDirection(compareResult: number, direction: ModuleSortDirection): 
 	return direction === 'desc' ? -compareResult : compareResult;
 }
 
-function getModuleKey(entry: CsmModuleEntry): string {
-	return `${entry.owner}/${entry.name}`;
-}

--- a/src/moduleManager/utils.ts
+++ b/src/moduleManager/utils.ts
@@ -1,0 +1,18 @@
+// ---------------------------------------------------------------------------
+// moduleManager/utils.ts — 模块管理器共享工具函数
+// ---------------------------------------------------------------------------
+
+import { CsmModuleEntry } from './types';
+
+/** 将模块条目转换为唯一标识键（owner/name）。 */
+export function getModuleKey(entry: CsmModuleEntry): string {
+	return `${entry.owner}/${entry.name}`;
+}
+
+/** 按最大长度截断文本，超出部分用 "..." 替代。 */
+export function truncate(text: string, maxLength: number): string {
+	if (text.length <= maxLength) {
+		return text;
+	}
+	return `${text.slice(0, maxLength - 3)}...`;
+}

--- a/src/test/vscode-mock.ts
+++ b/src/test/vscode-mock.ts
@@ -246,12 +246,8 @@ class MockWebviewView {
     private viewTitle: string | undefined;
     private viewDescription: string | undefined;
 
-    constructor(
-        onHtmlChange: (html: string) => void,
-        private readonly onTitleChange: (title: string | undefined) => void,
-        private readonly onDescriptionChange: (description: string | undefined) => void,
-    ) {
-        this.webview = new MockWebview(onHtmlChange);
+    constructor(private readonly onChange: () => void) {
+        this.webview = new MockWebview(() => this.onChange());
     }
 
     get title(): string | undefined {
@@ -260,7 +256,7 @@ class MockWebviewView {
 
     set title(value: string | undefined) {
         this.viewTitle = value;
-        this.onTitleChange(value);
+        this.onChange();
     }
 
     get description(): string | undefined {
@@ -269,7 +265,7 @@ class MockWebviewView {
 
     set description(value: string | undefined) {
         this.viewDescription = value;
-        this.onDescriptionChange(value);
+        this.onChange();
     }
 }
 
@@ -601,14 +597,8 @@ export function __resolveWebviewView(viewId: string): { html: string; fireMessag
     }
 
     const view = new MockWebviewView(
-        (html: string) => {
-            lastWebviewView = { viewId, html, title: view.title, description: view.description, options: cloneWebviewOptions(view.webview.options) };
-        },
-        (title: string | undefined) => {
-            lastWebviewView = { viewId, html: view.webview.html, title, description: view.description, options: cloneWebviewOptions(view.webview.options) };
-        },
-        (description: string | undefined) => {
-            lastWebviewView = { viewId, html: view.webview.html, title: view.title, description, options: cloneWebviewOptions(view.webview.options) };
+        () => {
+            lastWebviewView = { viewId, html: view.webview.html, title: view.title, description: view.description, options: cloneWebviewOptions(view.webview.options) };
         },
     );
     webviewViews.set(viewId, view);


### PR DESCRIPTION
在不改变任何现有功能的前提下，对代码库进行了三轮渐进式审查和优化：

### 第一轮 — 消除死代码与重复
- 删除 `csmlogDocumentSymbolProvider.ts` 中的连续双重 `entries.sort()`
- `getModuleKey` / `truncate` 提取到共享 `utils.ts`（消除 4 处重复）
- `lookupOperator` 简化：合并 `slice.includes()` + `indexOf()` 为单次 `indexOf()`
- `register()` 中 16 行 `wrapCommand` 模板提取为 `registerCommand()` 辅助方法
- `handleMessage` 的 176 行 switch-case → 声明式 `messageHandlers` 映射
- `labviewVersionDetector.ts` 中 3 个祖先遍历函数提取为 `walkUpAncestors()`
- `localizeHoverEntries` → `applyEnglishHoverTranslations`（澄清语义）
- `getWordAt` 中的 `new RegExp` 提取为模块常量 `WORD_CHAR`
- `esbuild.js` 清理无意义的注释

### 第二轮 — 深入消除模式重复
- `setWorkspaceContext` 中的 clear+for 模式提取为 `rebuildMap`/`rebuildSet`
- `applyEnglishHoverTranslations` 在无翻译时跳过对象拷贝
- `getCurrentLanguage()` 添加缓存，避免每次 hover/outline 重复解析
- `parseDevEnvironmentFileName` 统一返回值构建（消除 3 处相同格式字符串）
- `parseLvVersionFields` 提取共享 BCD 解码逻辑（消除 ~12 行重复）
- `csmlogHoverProvider` 的 FileLogger 分支复用 `parseLogLineZones`
- `MockWebviewView` 三回调合并为单一 `onChange`

### 验证
- TypeScript 编译零错误
- ESLint 零警告
- 26/26 测试全部通过