### PR TITLE
feat: 已归档模块仓库默认隐藏，新增 csmModules.hideArchivedRepos 配置项

### DIFF
--- a/package.json
+++ b/package.json
@@ -309,6 +309,12 @@
           "default": true,
           "scope": "window",
           "description": "%configuration.csmModules.autoStarModuleRepo.description%"
+        },
+        "csmModules.hideArchivedRepos": {
+          "type": "boolean",
+          "default": true,
+          "scope": "window",
+          "description": "%configuration.csmModules.hideArchivedRepos.description%"
         }
       }
     },

--- a/package.nls.json
+++ b/package.nls.json
@@ -22,5 +22,6 @@
   "configuration.csmModules.defaultModuleRoot.description": "Default relative directory used when initializing local CSM module management for a repository that does not already have a csm-modules.yaml file.",
   "configuration.csmModules.hiddenTopics.description": "Module repository topics to hide from the CSM Modules sidebar badges, tree tooltips, and local search text.",
   "configuration.csmModules.autoStarCsmCore.description": "Automatically star the CSM Core repository (NEVSTOP-LAB/Communicable-State-Machine) on GitHub when applying modules to the local workspace.",
-  "configuration.csmModules.autoStarModuleRepo.description": "Automatically star the downloaded module repository on GitHub when applying it to the local workspace."
+  "configuration.csmModules.autoStarModuleRepo.description": "Automatically star the downloaded module repository on GitHub when applying it to the local workspace.",
+  "configuration.csmModules.hideArchivedRepos.description": "Hide archived module repositories from the Available Modules list. When disabled, archived repositories are shown alongside active ones."
 }

--- a/package.nls.zh-cn.json
+++ b/package.nls.zh-cn.json
@@ -22,5 +22,6 @@
   "configuration.csmModules.defaultModuleRoot.description": "当仓库中尚不存在 csm-modules.yaml 文件时，用于初始化本地 CSM 模块管理的默认相对目录。",
   "configuration.csmModules.hiddenTopics.description": "用于配置在 CSM Modules 侧边栏徽标、树视图提示和本地搜索文本中隐藏的模块仓库 topics。",
   "configuration.csmModules.autoStarCsmCore.description": "将模块应用到本地工作区时，自动在 GitHub 上 Star CSM Core 仓库（NEVSTOP-LAB/Communicable-State-Machine）。",
-  "configuration.csmModules.autoStarModuleRepo.description": "将模块应用到本地工作区时，自动在 GitHub 上 Star 所下载模块对应的仓库。"
+  "configuration.csmModules.autoStarModuleRepo.description": "将模块应用到本地工作区时，自动在 GitHub 上 Star 所下载模块对应的仓库。",
+  "configuration.csmModules.hideArchivedRepos.description": "在可用模块列表中隐藏已归档的模块仓库。关闭后，已归档的仓库将与活跃仓库一同显示。"
 }

--- a/src/moduleManager/constants.ts
+++ b/src/moduleManager/constants.ts
@@ -39,6 +39,7 @@ export const CONFIG_KEYS = {
 	hiddenTopics: 'hiddenTopics',
 	autoStarCsmCore: 'autoStarCsmCore',
 	autoStarModuleRepo: 'autoStarModuleRepo',
+	hideArchivedRepos: 'hideArchivedRepos',
 } as const;
 
 export const STORAGE_KEYS = {

--- a/src/moduleManager/githubModuleService.ts
+++ b/src/moduleManager/githubModuleService.ts
@@ -118,8 +118,7 @@ export class GitHubModuleService {
 			repos.push(...(result.data.items ?? []).map(normalizeSearchRepo));
 			url = result.next ?? '';
 		}
-		const modules = dedupeRepos(repos).filter(hasModuleTopic).map(mapRepoToModuleEntry)
-			.sort((a, b) => a.name.localeCompare(b.name));
+		const modules = dedupeRepos(repos).filter(hasModuleTopic).map(mapRepoToModuleEntry).sort((a, b) => a.name.localeCompare(b.name));
 		return { modules, etag: firstResult.etag };
 	}
 

--- a/src/moduleManager/githubModuleService.ts
+++ b/src/moduleManager/githubModuleService.ts
@@ -103,7 +103,7 @@ export class GitHubModuleService {
 		};
 	}
 
-	public async fetchModules(token?: string, options: { etag?: string; hideArchivedRepos?: boolean } = {}): Promise<{ modules: CsmModuleEntry[]; etag?: string; notModified?: boolean }> {
+	public async fetchModules(token?: string, options: { etag?: string } = {}): Promise<{ modules: CsmModuleEntry[]; etag?: string; notModified?: boolean }> {
 		const searchQuery = encodeURIComponent(`topic:${MODULE_TOPIC}`);
 		const initialUrl = `${GITHUB_API_BASE}/search/repositories?per_page=${PER_PAGE}&q=${searchQuery}`;
 		// Conditional request: send If-None-Match only on the first page; if 304, short-circuit.
@@ -118,9 +118,7 @@ export class GitHubModuleService {
 			repos.push(...(result.data.items ?? []).map(normalizeSearchRepo));
 			url = result.next ?? '';
 		}
-		const hideArchived = options.hideArchivedRepos !== false;
 		const modules = dedupeRepos(repos).filter(hasModuleTopic).map(mapRepoToModuleEntry)
-			.filter((m) => !hideArchived || !m.archived)
 			.sort((a, b) => a.name.localeCompare(b.name));
 		return { modules, etag: firstResult.etag };
 	}

--- a/src/moduleManager/githubModuleService.ts
+++ b/src/moduleManager/githubModuleService.ts
@@ -46,6 +46,7 @@ export function mapRepoToModuleEntry(repo: GitHubRepoSummary): CsmModuleEntry {
 		description: repo.description ?? '',
 		topics,
 		visibility: repo.private ? 'private' : 'public',
+		archived: repo.archived,
 		defaultBranch: repo.default_branch,
 		repoUrl: repo.html_url,
 		updatedAt: repo.updated_at,
@@ -102,7 +103,7 @@ export class GitHubModuleService {
 		};
 	}
 
-	public async fetchModules(token?: string, options: { etag?: string } = {}): Promise<{ modules: CsmModuleEntry[]; etag?: string; notModified?: boolean }> {
+	public async fetchModules(token?: string, options: { etag?: string; hideArchivedRepos?: boolean } = {}): Promise<{ modules: CsmModuleEntry[]; etag?: string; notModified?: boolean }> {
 		const searchQuery = encodeURIComponent(`topic:${MODULE_TOPIC}`);
 		const initialUrl = `${GITHUB_API_BASE}/search/repositories?per_page=${PER_PAGE}&q=${searchQuery}`;
 		// Conditional request: send If-None-Match only on the first page; if 304, short-circuit.
@@ -117,7 +118,10 @@ export class GitHubModuleService {
 			repos.push(...(result.data.items ?? []).map(normalizeSearchRepo));
 			url = result.next ?? '';
 		}
-		const modules = dedupeRepos(repos).filter(hasModuleTopic).map(mapRepoToModuleEntry).sort((a, b) => a.name.localeCompare(b.name));
+		const hideArchived = options.hideArchivedRepos !== false;
+		const modules = dedupeRepos(repos).filter(hasModuleTopic).map(mapRepoToModuleEntry)
+			.filter((m) => !hideArchived || !m.archived)
+			.sort((a, b) => a.name.localeCompare(b.name));
 		return { modules, etag: firstResult.etag };
 	}
 

--- a/src/moduleManager/moduleManagerController.ts
+++ b/src/moduleManager/moduleManagerController.ts
@@ -1515,7 +1515,8 @@ export class ModuleManagerController {
 		try {
 			const cachedSnapshot = this.cacheStore.getModuleSnapshot();
 			const previousEtag = this.cacheStore.getModuleEtag();
-			const fetchResult = await this.githubService.fetchModules(token, { etag: previousEtag });
+			const hideArchivedRepos = vscode.workspace.getConfiguration(CONFIG_SECTIONS.moduleManager).get<boolean>(CONFIG_KEYS.hideArchivedRepos, true);
+			const fetchResult = await this.githubService.fetchModules(token, { etag: previousEtag, hideArchivedRepos });
 
 			if (fetchResult.notModified) {
 				// 304 Not Modified：使用缓存数据，仅在必要时补充 star 状态

--- a/src/moduleManager/moduleManagerController.ts
+++ b/src/moduleManager/moduleManagerController.ts
@@ -1551,8 +1551,12 @@ export class ModuleManagerController {
 
 			// 新数据到达：立即预览渲染模块卡片，让用户看到内容
 			const modules = fetchResult.modules;
+			// 预览阶段同样遵循 hideArchivedRepos 配置，避免已归档仓库闪现
+			const previewModules = vscode.workspace.getConfiguration(CONFIG_SECTIONS.moduleManager).get<boolean>(CONFIG_KEYS.hideArchivedRepos, true)
+				? modules.filter((m) => !m.archived)
+				: modules;
 			if (!options.preserveVisibleModules && typeof this.treeDataProvider.setModulesPreview === 'function') {
-				this.treeDataProvider.setModulesPreview(modules);
+				this.treeDataProvider.setModulesPreview(previewModules);
 			}
 
 			// 阶段 3：并行补充 star 状态和 README 预加载

--- a/src/moduleManager/moduleManagerController.ts
+++ b/src/moduleManager/moduleManagerController.ts
@@ -1515,8 +1515,7 @@ export class ModuleManagerController {
 		try {
 			const cachedSnapshot = this.cacheStore.getModuleSnapshot();
 			const previousEtag = this.cacheStore.getModuleEtag();
-			const hideArchivedRepos = vscode.workspace.getConfiguration(CONFIG_SECTIONS.moduleManager).get<boolean>(CONFIG_KEYS.hideArchivedRepos, true);
-			const fetchResult = await this.githubService.fetchModules(token, { etag: previousEtag, hideArchivedRepos });
+			const fetchResult = await this.githubService.fetchModules(token, { etag: previousEtag });
 
 			if (fetchResult.notModified) {
 				// 304 Not Modified：使用缓存数据，仅在必要时补充 star 状态
@@ -1853,9 +1852,12 @@ export class ModuleManagerController {
 			: this.shouldRevealPrivateCache(snapshot)
 				? modules
 				: modules.filter((module) => module.visibility === 'public');
+		// 根据配置过滤已归档模块（默认隐藏，用户可通过 csmModules.hideArchivedRepos 关闭）
+		const hideArchived = vscode.workspace.getConfiguration(CONFIG_SECTIONS.moduleManager).get<boolean>(CONFIG_KEYS.hideArchivedRepos, true);
+		const visibleModules = hideArchived ? result.filter((module) => !module.archived) : result;
 		// 合并远程 LV 版本缓存
 		const lvCache = this.cacheStore.getLvVersionCache();
-		return result.map((m) => {
+		return visibleModules.map((m) => {
 			const moduleKey = this.getModuleKey(m);
 			const cachedVersion = lvCache[moduleKey];
 			// 优先使用 GitHub topics 提取的版本，回退到远程缓存

--- a/src/moduleManager/moduleManagerController.ts
+++ b/src/moduleManager/moduleManagerController.ts
@@ -1551,12 +1551,8 @@ export class ModuleManagerController {
 
 			// 新数据到达：立即预览渲染模块卡片，让用户看到内容
 			const modules = fetchResult.modules;
-			// 预览阶段同样遵循 hideArchivedRepos 配置，避免已归档仓库闪现
-			const previewModules = vscode.workspace.getConfiguration(CONFIG_SECTIONS.moduleManager).get<boolean>(CONFIG_KEYS.hideArchivedRepos, true)
-				? modules.filter((m) => !m.archived)
-				: modules;
 			if (!options.preserveVisibleModules && typeof this.treeDataProvider.setModulesPreview === 'function') {
-				this.treeDataProvider.setModulesPreview(previewModules);
+				this.treeDataProvider.setModulesPreview(this.filterArchivedModules(modules));
 			}
 
 			// 阶段 3：并行补充 star 状态和 README 预加载
@@ -1849,6 +1845,15 @@ export class ModuleManagerController {
 		return typeof knownAccountId === 'string' && knownAccountId === snapshot.refreshAccountId;
 	}
 
+	/**
+	 * 根据 csmModules.hideArchivedRepos 配置过滤已归档模块。
+	 * 配置默认值为 true（隐藏已归档仓库），用户可关闭以显示全部。
+	 */
+	private filterArchivedModules(modules: CsmModuleEntry[]): CsmModuleEntry[] {
+		const hideArchived = vscode.workspace.getConfiguration(CONFIG_SECTIONS.moduleManager).get<boolean>(CONFIG_KEYS.hideArchivedRepos, true);
+		return hideArchived ? modules.filter((m) => !m.archived) : modules;
+	}
+
 	private getVisibleModulesFromSnapshot(snapshot: ModuleCacheSnapshot | undefined): CsmModuleEntry[] {
 		const modules = snapshot?.modules ?? [];
 		const result = !modules.some((module) => module.visibility === 'private')
@@ -1856,9 +1861,7 @@ export class ModuleManagerController {
 			: this.shouldRevealPrivateCache(snapshot)
 				? modules
 				: modules.filter((module) => module.visibility === 'public');
-		// 根据配置过滤已归档模块（默认隐藏，用户可通过 csmModules.hideArchivedRepos 关闭）
-		const hideArchived = vscode.workspace.getConfiguration(CONFIG_SECTIONS.moduleManager).get<boolean>(CONFIG_KEYS.hideArchivedRepos, true);
-		const visibleModules = hideArchived ? result.filter((module) => !module.archived) : result;
+		const visibleModules = this.filterArchivedModules(result);
 		// 合并远程 LV 版本缓存
 		const lvCache = this.cacheStore.getLvVersionCache();
 		return visibleModules.map((m) => {

--- a/src/moduleManager/types.ts
+++ b/src/moduleManager/types.ts
@@ -5,6 +5,7 @@ export interface CsmModuleEntry {
 	description: string;
 	topics: string[];
 	visibility: 'public' | 'private';
+	archived?: boolean;
 	defaultBranch: string;
 	repoUrl: string;
 	starred?: boolean;
@@ -100,6 +101,7 @@ export interface GitHubRepoSummary {
 	full_name: string;
 	description: string | null;
 	private: boolean;
+	archived?: boolean;
 	default_branch: string;
 	html_url: string;
 	topics?: string[];


### PR DESCRIPTION
- GitHubRepoSummary / CsmModuleEntry 新增 archived 字段
- githubModuleService.fetchModules 支持 hideArchivedRepos 选项（默认 true）
- 控制器从配置读取并传递 hideArchivedRepos
- package.json 新增 boolean 配置项，默认隐藏已归档仓库