### PR TITLE
feat: 刷新/应用模块操作增强进度反馈 (fix #54)

### DIFF
--- a/src/moduleManager/githubModuleService.ts
+++ b/src/moduleManager/githubModuleService.ts
@@ -8,6 +8,7 @@ const MODULE_TOPIC = GITHUB.moduleTopic;
 const PER_PAGE = GITHUB.perPage;
 
 interface GitHubSearchResponse<T> {
+	total_count?: number;
 	items?: T[];
 }
 
@@ -105,23 +106,26 @@ export class GitHubModuleService {
 		};
 	}
 
-	public async fetchModules(token?: string, options: { etag?: string } = {}): Promise<{ modules: CsmModuleEntry[]; etag?: string; notModified?: boolean }> {
+	public async fetchModules(token?: string, options: { etag?: string; onProgress?: (fetched: number, total: number) => void } = {}): Promise<{ modules: CsmModuleEntry[]; totalCount?: number; etag?: string; notModified?: boolean }> {
 		const searchQuery = encodeURIComponent(`topic:${MODULE_TOPIC}`);
 		const initialUrl = `${GITHUB_API_BASE}/search/repositories?per_page=${PER_PAGE}&q=${searchQuery}`;
 		// Conditional request: send If-None-Match only on the first page; if 304, short-circuit.
 		const firstResult = await this.requestJson<GitHubSearchResponse<GitHubRepoSummary>>(initialUrl, token, options.etag);
 		if (firstResult.notModified) {
-			return { modules: [], etag: firstResult.etag, notModified: true };
+			return { modules: [], totalCount: 0, etag: firstResult.etag, notModified: true };
 		}
 		const repos: GitHubRepoSummary[] = [...(firstResult.data.items ?? []).map(normalizeSearchRepo)];
+		const totalCount = firstResult.data.total_count ?? repos.length;
+		options.onProgress?.(repos.length, totalCount);
 		let url = firstResult.next ?? '';
 		while (url) {
 			const result = await this.requestJson<GitHubSearchResponse<GitHubRepoSummary>>(url, token);
 			repos.push(...(result.data.items ?? []).map(normalizeSearchRepo));
+			options.onProgress?.(repos.length, totalCount);
 			url = result.next ?? '';
 		}
 		const modules = dedupeRepos(repos).filter(hasModuleTopic).map(mapRepoToModuleEntry).sort((a, b) => a.name.localeCompare(b.name));
-		return { modules, etag: firstResult.etag };
+		return { modules, totalCount, etag: firstResult.etag };
 	}
 
 	public async fetchReadme(owner: string, repo: string, token?: string): Promise<string> {

--- a/src/moduleManager/messages.ts
+++ b/src/moduleManager/messages.ts
@@ -234,6 +234,22 @@ const messages = {
 		en: 'Switched {module} to {method}.',
 		zh: '已将 {module} 切换为 {method}。',
 	},
+	applyingSubmoduleAdding: {
+		en: 'Adding submodule {repo}...',
+		zh: '正在添加子模块 {repo}...',
+	},
+	applyingSubmoduleInit: {
+		en: 'Initializing submodule {repo}...',
+		zh: '正在初始化子模块 {repo}...',
+	},
+	applyingCopyCloning: {
+		en: 'Cloning {repo} from GitHub...',
+		zh: '正在从 GitHub 克隆 {repo}...',
+	},
+	applyingCopyFiles: {
+		en: 'Copying {repo} files...',
+		zh: '正在复制 {repo} 文件...',
+	},
 	switchMethodSuccessWithBackup: {
 		en: 'Switched {module} to {method}. Backup saved to {backupPath}.',
 		zh: '已将 {module} 切换为 {method}。备份已保存到 {backupPath}。',

--- a/src/moduleManager/messages.ts
+++ b/src/moduleManager/messages.ts
@@ -314,9 +314,17 @@ const messages = {
 		en: 'Fetching module catalog...',
 		zh: '正在获取模块目录...',
 	},
+	fetchingCatalogProgress: {
+		en: 'Fetched {fetched}/{total} modules...',
+		zh: '已获取 {fetched}/{total} 个模块...',
+	},
 	checkingUpdates: {
 		en: 'Checking for updates...',
 		zh: '正在检查更新...',
+	},
+	loadingDetailsProgress: {
+		en: 'Loading module details {done}/{total}...',
+		zh: '正在加载模块详情 {done}/{total}...',
 	},
 	preloadingReadme: {
 		en: 'Preloading README files...',

--- a/src/moduleManager/moduleManagerController.ts
+++ b/src/moduleManager/moduleManagerController.ts
@@ -1571,7 +1571,7 @@ export class ModuleManagerController {
 
 			// 阶段 3：并行补充 star 状态和 README 预加载
 			if (!options.preserveVisibleModules) {
-				this.treeDataProvider.setLoading(t('loadingDetailsProgress', { done: 0, total: modules.length }));
+				this.treeDataProvider.setLoading(t('loadingDetailsProgress', { done: 0, total: modules.length * 2 }));
 			}
 
 			const detailProgress = { stars: 0, readmes: 0 };

--- a/src/moduleManager/moduleManagerController.ts
+++ b/src/moduleManager/moduleManagerController.ts
@@ -1429,6 +1429,7 @@ export class ModuleManagerController {
 
 	private async hydrateStarStates(modules: CsmModuleEntry[], token: string | undefined, onProgress?: (done: number, total: number) => void): Promise<CsmModuleEntry[]> {
 		if (modules.length === 0 || !token || typeof this.githubService.isRepositoryStarred !== 'function') {
+			onProgress?.(modules.length, modules.length);
 			return modules;
 		}
 		const starStates = await this.fetchStarStatesParallel(modules, token, 8, onProgress);

--- a/src/moduleManager/moduleManagerController.ts
+++ b/src/moduleManager/moduleManagerController.ts
@@ -339,6 +339,7 @@ export class ModuleManagerController {
 									moduleEntry,
 									applyMethod,
 									authToken,
+									(msg) => progress.report({ message: msg }),
 								);
 								progress.report({
 									increment: 100 / selectedEntries.length,
@@ -378,6 +379,7 @@ export class ModuleManagerController {
 								moduleEntry,
 								applyMethod,
 								authToken,
+								(msg) => progress.report({ message: msg }),
 							);
 							config = this.workspaceModuleService.withAppliedModule(config, applied);
 							await writeConfigSafely(config);
@@ -1425,11 +1427,11 @@ export class ModuleManagerController {
 		}
 	}
 
-	private async hydrateStarStates(modules: CsmModuleEntry[], token: string | undefined): Promise<CsmModuleEntry[]> {
+	private async hydrateStarStates(modules: CsmModuleEntry[], token: string | undefined, onProgress?: (done: number, total: number) => void): Promise<CsmModuleEntry[]> {
 		if (modules.length === 0 || !token || typeof this.githubService.isRepositoryStarred !== 'function') {
 			return modules;
 		}
-		const starStates = await this.fetchStarStatesParallel(modules, token, 8);
+		const starStates = await this.fetchStarStatesParallel(modules, token, 8, onProgress);
 		return modules.map((moduleEntry) => ({
 			...moduleEntry,
 			starred: starStates.get(this.getModuleKey(moduleEntry)),
@@ -1440,6 +1442,7 @@ export class ModuleManagerController {
 		modules: CsmModuleEntry[],
 		token: string,
 		concurrency: number,
+		onProgress?: (done: number, total: number) => void,
 	): Promise<Map<string, boolean>> {
 		const starredStates = new Map<string, boolean>();
 		const isRepositoryStarred = this.githubService.isRepositoryStarred?.bind(this.githubService);
@@ -1447,6 +1450,8 @@ export class ModuleManagerController {
 			return starredStates;
 		}
 		let cursor = 0;
+		let completed = 0;
+		const total = modules.length;
 		const worker = async (): Promise<void> => {
 			while (cursor < modules.length) {
 				const index = cursor;
@@ -1461,6 +1466,8 @@ export class ModuleManagerController {
 				} catch (error) {
 					this.logger.warn(`Failed to fetch star state for ${moduleEntry.owner}/${moduleEntry.name}: ${error instanceof Error ? error.message : String(error)}`);
 				}
+				completed += 1;
+				onProgress?.(completed, total);
 			}
 		};
 		const workerCount = Math.max(1, Math.min(concurrency, modules.length));
@@ -1515,7 +1522,14 @@ export class ModuleManagerController {
 		try {
 			const cachedSnapshot = this.cacheStore.getModuleSnapshot();
 			const previousEtag = this.cacheStore.getModuleEtag();
-			const fetchResult = await this.githubService.fetchModules(token, { etag: previousEtag });
+			const fetchResult = await this.githubService.fetchModules(token, {
+				etag: previousEtag,
+				onProgress: (fetched, total) => {
+					if (!options.preserveVisibleModules) {
+						this.treeDataProvider.setLoading(t('fetchingCatalogProgress', { fetched, total }));
+					}
+				},
+			});
 
 			if (fetchResult.notModified) {
 				// 304 Not Modified：使用缓存数据，仅在必要时补充 star 状态
@@ -1557,12 +1571,27 @@ export class ModuleManagerController {
 
 			// 阶段 3：并行补充 star 状态和 README 预加载
 			if (!options.preserveVisibleModules) {
-				this.treeDataProvider.setLoading(t('loadingStarStatus'));
+				this.treeDataProvider.setLoading(t('loadingDetailsProgress', { done: 0, total: modules.length }));
 			}
 
+			const detailProgress = { stars: 0, readmes: 0 };
+			const updateDetailProgress = () => {
+				if (!options.preserveVisibleModules) {
+					this.treeDataProvider.setLoading(
+						t('loadingDetailsProgress', { done: detailProgress.stars + detailProgress.readmes, total: modules.length * 2 }),
+					);
+				}
+			};
+
 			const [modulesWithStarState, refreshedReadme] = await Promise.all([
-				this.hydrateStarStates(modules, token),
-				this.fetchReadmesParallel(modules, token, 5),
+				this.hydrateStarStates(modules, token, (done) => {
+					detailProgress.stars = done;
+					updateDetailProgress();
+				}),
+				this.fetchReadmesParallel(modules, token, 5, (done) => {
+					detailProgress.readmes = done;
+					updateDetailProgress();
+				}),
 			]);
 			this.availableModules = modulesWithStarState;
 			// Parallelized README prefetch with bounded concurrency to avoid blocking on large lists.
@@ -1658,9 +1687,12 @@ export class ModuleManagerController {
 		modules: CsmModuleEntry[],
 		token: string | undefined,
 		concurrency: number,
+		onProgress?: (done: number, total: number) => void,
 	): Promise<Record<string, string>> {
 		const refreshed: Record<string, string> = {};
 		let cursor = 0;
+		let completed = 0;
+		const total = modules.length;
 		const worker = async (): Promise<void> => {
 			while (cursor < modules.length) {
 				const index = cursor;
@@ -1678,6 +1710,8 @@ export class ModuleManagerController {
 					this.logger.warn(`Failed to fetch README for ${moduleEntry.owner}/${moduleEntry.name}: ${error instanceof Error ? error.message : String(error)}`);
 					refreshed[key] = '';
 				}
+				completed += 1;
+				onProgress?.(completed, total);
 			}
 		};
 		const workerCount = Math.max(1, Math.min(concurrency, modules.length));

--- a/src/moduleManager/workspaceModuleService.ts
+++ b/src/moduleManager/workspaceModuleService.ts
@@ -5,6 +5,7 @@ import * as path from 'path';
 import JSZip from 'jszip';
 import * as yaml from 'js-yaml';
 import { CopyModuleUpdatePreview, CsmModuleEntry, LocalModuleConfig, LocalModuleConfigEntry, ModuleApplyMethod, ModuleUpdateResult } from './types';
+import { t } from './messages';
 import { GitService, IGitRunner } from './gitService';
 
 const CONFIG_VERSION = '2';
@@ -689,14 +690,14 @@ export class WorkspaceModuleService {
 		onProgress?: (message: string) => void,
 	): Promise<LocalModuleConfigEntry> {
 		const branch = entry.defaultBranch || 'main';
-		onProgress?.(`Adding submodule ${entry.owner}/${entry.name}...`);
+		onProgress?.(t('applyingSubmoduleAdding', { repo: `${entry.owner}/${entry.name}` }));
 		await this.runGit(
 			repoRoot,
 			['submodule', 'add', '-b', branch, entry.repoUrl, targetRelativePath],
 			authToken,
 			entry.repoUrl,
 		);
-		onProgress?.(`Initializing submodule ${entry.owner}/${entry.name}...`);
+		onProgress?.(t('applyingSubmoduleInit', { repo: `${entry.owner}/${entry.name}` }));
 		await this.runGit(
 			repoRoot,
 			['submodule', 'update', '--init', '--recursive', targetRelativePath],
@@ -724,10 +725,10 @@ export class WorkspaceModuleService {
 				cloneArgs.push('--branch', entry.defaultBranch);
 			}
 			cloneArgs.push(entry.repoUrl, checkoutPath);
-			onProgress?.(`Cloning ${entry.owner}/${entry.name} from GitHub...`);
+			onProgress?.(t('applyingCopyCloning', { repo: `${entry.owner}/${entry.name}` }));
 			await this.runGit(repoRoot, cloneArgs, authToken, entry.repoUrl);
 			const ref = await this.runGit(checkoutPath, ['rev-parse', 'HEAD']);
-			onProgress?.(`Copying ${entry.owner}/${entry.name} files...`);
+			onProgress?.(t('applyingCopyFiles', { repo: `${entry.owner}/${entry.name}` }));
 			await fs.mkdir(path.dirname(targetPath), { recursive: true });
 			await this.copyDirectory(checkoutPath, targetPath);
 			return this.createConfigEntry(entry, 'copy', targetRelativePath, ref, branch);

--- a/src/moduleManager/workspaceModuleService.ts
+++ b/src/moduleManager/workspaceModuleService.ts
@@ -542,6 +542,7 @@ export class WorkspaceModuleService {
 		entry: CsmModuleEntry,
 		method: ModuleApplyMethod,
 		authToken?: string,
+		onProgress?: (message: string) => void,
 	): Promise<LocalModuleConfigEntry> {
 		const targetRelativePath = this.getTargetRelativePath(config, entry);
 		const targetPath = this.toAbsoluteTargetPath(repoRoot, targetRelativePath);
@@ -553,8 +554,8 @@ export class WorkspaceModuleService {
 		}
 
 		const appliedEntry = method === 'submodule'
-			? this.applyModuleAsSubmodule(repoRoot, entry, targetRelativePath, targetPath, authToken)
-			: this.applyModuleAsCopy(repoRoot, entry, targetRelativePath, targetPath, authToken);
+			? this.applyModuleAsSubmodule(repoRoot, entry, targetRelativePath, targetPath, authToken, onProgress)
+			: this.applyModuleAsCopy(repoRoot, entry, targetRelativePath, targetPath, authToken, onProgress);
 		const lockedEntry = this.normalizeConfigEntry(await appliedEntry);
 		await this.applyEntryLockState(repoRoot, lockedEntry);
 		return lockedEntry;
@@ -685,14 +686,17 @@ export class WorkspaceModuleService {
 		targetRelativePath: string,
 		targetPath: string,
 		authToken?: string,
+		onProgress?: (message: string) => void,
 	): Promise<LocalModuleConfigEntry> {
 		const branch = entry.defaultBranch || 'main';
+		onProgress?.(`Adding submodule ${entry.owner}/${entry.name}...`);
 		await this.runGit(
 			repoRoot,
 			['submodule', 'add', '-b', branch, entry.repoUrl, targetRelativePath],
 			authToken,
 			entry.repoUrl,
 		);
+		onProgress?.(`Initializing submodule ${entry.owner}/${entry.name}...`);
 		await this.runGit(
 			repoRoot,
 			['submodule', 'update', '--init', '--recursive', targetRelativePath],
@@ -709,6 +713,7 @@ export class WorkspaceModuleService {
 		targetRelativePath: string,
 		targetPath: string,
 		authToken?: string,
+		onProgress?: (message: string) => void,
 	): Promise<LocalModuleConfigEntry> {
 		const tempRoot = await fs.mkdtemp(path.join(os.tmpdir(), 'csm-module-'));
 		const checkoutPath = path.join(tempRoot, 'checkout');
@@ -719,8 +724,10 @@ export class WorkspaceModuleService {
 				cloneArgs.push('--branch', entry.defaultBranch);
 			}
 			cloneArgs.push(entry.repoUrl, checkoutPath);
+			onProgress?.(`Cloning ${entry.owner}/${entry.name} from GitHub...`);
 			await this.runGit(repoRoot, cloneArgs, authToken, entry.repoUrl);
 			const ref = await this.runGit(checkoutPath, ['rev-parse', 'HEAD']);
+			onProgress?.(`Copying ${entry.owner}/${entry.name} files...`);
 			await fs.mkdir(path.dirname(targetPath), { recursive: true });
 			await this.copyDirectory(checkoutPath, targetPath);
 			return this.createConfigEntry(entry, 'copy', targetRelativePath, ref, branch);


### PR DESCRIPTION
## 概述

修复 #54 — 网络较慢时下载模块无进度反馈的问题。在所有关键操作中增加实时进度提示。

## 修改

| 文件 | 变更 |
|---|---|
| `githubModuleService.ts` | `fetchModules` 新增 `onProgress(fetched, total)` 回调 |
| `moduleManagerController.ts` | `loadModules` 三段显示数量进度；`hydrateStarStates`/`fetchReadmesParallel` 新增 `onProgress` |
| `workspaceModuleService.ts` | `applyModule`/`AsSubmodule`/`AsCopy` 新增子步骤进度 |
| `messages.ts` | 新增 `fetchingCatalogProgress` + `loadingDetailsProgress` |

## 用户可见效果

| 操作 | 之前 | 之后 |
|---|---|---|
| Refresh 拉取目录 | 静态 loading | "已获取 45/120 个模块..."（实时更新） |
| Refresh 加载详情 | 静态 loading | "正在加载模块详情 67/240..." |
| Apply (submodule) | "org/repo" | "Adding submodule..." → "Initializing..." |
| Apply (copy) | "org/repo" | "Cloning..." → "Copying files..." |