### PR TITLE
refactor: 代码审查清理 — 死代码删除、错误处理修复

### DIFF
--- a/src/moduleManager/commands/index.ts
+++ b/src/moduleManager/commands/index.ts
@@ -30,11 +30,6 @@ export class LoginCommand {
 	execute(): Promise<void> { return this.target.loginCommand(); }
 }
 
-export class LogoutCommand {
-	constructor(private readonly target: CommandTarget) { }
-	execute(): Promise<void> { return this.target.logoutCommand(); }
-}
-
 export class RefreshCommand {
 	constructor(private readonly target: CommandTarget) { }
 	execute(): Promise<void> { return this.target.refreshCommand(); }

--- a/src/moduleManager/gitService.ts
+++ b/src/moduleManager/gitService.ts
@@ -60,7 +60,6 @@ export class GitService implements IGitRunner {
 	public async exec(options: GitExecOptions): Promise<string> {
 		const { cwd, args, authToken, repoUrl } = options;
 		const env = { ...process.env };
-		const cleanupTasks: Array<() => Promise<void>> = [];
 
 		if (authToken && this.usesHttpsRemote(repoUrl)) {
 			const askpass = await this.ensureAskpassScript();
@@ -81,14 +80,6 @@ export class GitService implements IGitRunner {
 			return stdout.trim();
 		} catch (error) {
 			throw new Error(formatCommandError(error));
-		} finally {
-			for (const task of cleanupTasks) {
-				try {
-					await task();
-				} catch {
-					// best effort
-				}
-			}
 		}
 	}
 

--- a/src/moduleManager/moduleManagerController.ts
+++ b/src/moduleManager/moduleManagerController.ts
@@ -243,7 +243,10 @@ export class ModuleManagerController {
 			void vscode.window.showErrorMessage(t('commandErrorPrefix', { message }));
 		});
 
-		void this.refreshWorkspaceInitializationState({ prompt: true });
+		const initRefresh = this.refreshWorkspaceInitializationState({ prompt: true });
+		void initRefresh.catch((error) => {
+			this.logger.error(`Failed to refresh workspace initialization state during registration: ${error instanceof Error ? error.message : String(error)}`);
+		});
 	}
 
 	public async applyToWorkspaceCommand(entry?: CsmModuleEntry | ModuleTreeItem, useOnlyEntry = false): Promise<void> {
@@ -333,19 +336,22 @@ export class ModuleManagerController {
 						// then atomically merge into config in one write (review item 2.4).
 						const settled = await Promise.allSettled(
 							selectedEntries.map(async (moduleEntry) => {
-								const applied = await this.workspaceModuleService.applyModule(
-									applyRoot,
-									config,
-									moduleEntry,
-									applyMethod,
-									authToken,
-									(msg) => progress.report({ message: msg }),
-								);
-								progress.report({
-									increment: 100 / selectedEntries.length,
-									message: `${moduleEntry.owner}/${moduleEntry.name}`,
-								});
-								return applied;
+								try {
+									const applied = await this.workspaceModuleService.applyModule(
+										applyRoot,
+										config,
+										moduleEntry,
+										applyMethod,
+										authToken,
+										(msg) => progress.report({ message: msg }),
+									);
+									return applied;
+								} finally {
+									progress.report({
+										increment: 100 / selectedEntries.length,
+										message: `${moduleEntry.owner}/${moduleEntry.name}`,
+									});
+								}
 							}),
 						);
 						const successes: LocalModuleConfigEntry[] = [];


### PR DESCRIPTION
## 概述

全仓库 review 后发现的修复，两轮 review-fix-commit 迭代。

## 修改

| 提交 | 内容 |
|---|---|
| `e39f667` | 删除 `LogoutCommand` 死类 + `gitService` 未使用 `cleanupTasks` |
| `6d525fc` | 修复 `register()` 未处理 promise reject；copy 模式 apply 失败时进度跳过 |