### PR TITLE
fix: push to main 不再自动发布 pre-release 到 Marketplace

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,6 +9,13 @@ on:
   pull_request:
     branches:
       - main
+  workflow_dispatch:
+    inputs:
+      publish_to_marketplace:
+        description: '发布 pre-release 到 VS Code Marketplace'
+        type: boolean
+        required: false
+        default: false
 
 permissions:
   contents: read
@@ -307,7 +314,7 @@ jobs:
     name: 发布到 VS Code Marketplace
     runs-on: ubuntu-latest
     needs: [build-vsix, validate-vsix]
-    if: github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/tags/')
+    if: (github.event_name == 'workflow_dispatch' && github.event.inputs.publish_to_marketplace == 'true') || startsWith(github.ref, 'refs/tags/')
     steps:
       - name: 安装 Node.js
         uses: actions/setup-node@v4


### PR DESCRIPTION
## 问题

每次 push 到 main 自动发布 pre-release 到 VS Code Marketplace，触发限速。

## 修改

1. 新增 `workflow_dispatch` 手动触发，含 `publish_to_marketplace` checkbox（默认不勾）
2. `publish-to-marketplace` job 条件改为：
   - Tag push → 自动发布（正式 Release）
   - `workflow_dispatch` + 勾选 checkbox → 手动发布
   - Push 到 main → **不再自动发布**

## 触发行为

| 事件 | 发布? |
|---|---|
| push 到 main | ❌ |
| push tag `v*` | ✅ 自动 |
| workflow_dispatch（默认）| ❌ |
| workflow_dispatch（勾选）| ✅ 手动 |