### PR TITLE
feat: support nested module namespace placement in module apply flow

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,13 +8,13 @@
 
 ## 功能概览
 
-| 功能 | 说明 |
-|---|---|
-| `.csmlog` 日志支持 | 语法高亮、Hover 悬停提示、Outline 大纲、**智能重复折叠**、自动编码识别 |
-| `.lvcsm` 配置文件支持 | 语法高亮、Outline 大纲、自动编码识别 |
-| `CSM Modules` 模块管理 | 侧边栏浏览、搜索、引入、更新、移除 CSM 模块，支持 GitHub 登录、批量操作，以及将模块放置到模块根目录或嵌套命名空间 |
-| 文件装饰 (File Decorations) | 为 `.csmlog` (C) 与 `.lvcsm` (L) 添加 Badge 标记，可与任意图标主题共存 |
-| 本地化 | 中文 / 英文界面切换 |
+| 功能                        | 说明                                                                                                       |
+|-----------------------------|------------------------------------------------------------------------------------------------------------|
+| `.csmlog` 日志支持          | 语法高亮、Hover 悬停提示、Outline 大纲、**智能重复折叠**、自动编码识别                                         |
+| `.lvcsm` 配置文件支持       | 语法高亮、Outline 大纲、自动编码识别                                                                         |
+| `CSM Modules` 模块管理      | 侧边栏浏览、搜索、引入、更新、移除 CSM 模块，支持 GitHub 登录、批量操作，以及将模块放置到模块根目录或嵌套命名空间 |
+| 文件装饰 (File Decorations) | 为 `.csmlog` (C) 与 `.lvcsm` (L) 添加 Badge 标记，可与任意图标主题共存                                      |
+| 本地化                      | 中文 / 英文界面切换                                                                                        |
 
 ## 快速入口
 
@@ -26,16 +26,16 @@
 
 ## 扩展设置
 
-| 设置项 | 默认值 | 说明 |
-|---|---|---|
-| `csmModules.defaultModuleRoot` | `csm` | 首次引入模块时预填的默认目录名 |
-| `csmModules.moduleScanMaxDepth` | `3` | 递归发现本地模块候选目录时允许的最大深度 |
-| `csmModules.moduleScanIncludeReadmeWeakSignal` | `true` | 启用 README 弱信号后，包含 README 且至少有一个非文档文件的目录也可被识别为模块候选 |
-| `csmModules.hiddenTopics` | `csm-modsets`, `lv-csm-app`, `labview-csm`, `labview` | 侧边栏中默认隐藏的 topic |
-| `csmlog.folding.minRepeatCount` | `3` | 最少连续重复几次触发折叠 |
-| `csmlog.folding.maxBlockLines` | `20` | 多行块匹配的最大行数 |
-| `csmlog.folding.smartParams` | `true` | 启用参数归一化，消息模板相同仅参数不同的行也折叠 |
-| `csmlog.folding.decorationStyle` | `compact` | 折叠概要标签样式（compact: ×42 / detailed: 含时间） |
+| 设置项                                         | 默认值                                                | 说明                                                                              |
+|------------------------------------------------|-------------------------------------------------------|-----------------------------------------------------------------------------------|
+| `csmModules.defaultModuleRoot`                 | `csm`                                                 | 首次引入模块时预填的默认目录名                                                    |
+| `csmModules.moduleScanMaxDepth`                | `3`                                                   | 递归发现本地模块候选目录时允许的最大深度                                          |
+| `csmModules.moduleScanIncludeReadmeWeakSignal` | `true`                                                | 启用 README 弱信号后，包含 README 且至少有一个非文档文件的目录也可被识别为模块候选 |
+| `csmModules.hiddenTopics`                      | `csm-modsets`, `lv-csm-app`, `labview-csm`, `labview` | 侧边栏中默认隐藏的 topic                                                          |
+| `csmlog.folding.minRepeatCount`                | `3`                                                   | 最少连续重复几次触发折叠                                                          |
+| `csmlog.folding.maxBlockLines`                 | `20`                                                  | 多行块匹配的最大行数                                                              |
+| `csmlog.folding.smartParams`                   | `true`                                                | 启用参数归一化，消息模板相同仅参数不同的行也折叠                                   |
+| `csmlog.folding.decorationStyle`               | `compact`                                             | 折叠概要标签样式（compact: ×42 / detailed: 含时间）                                 |
 
 ## 更多文档
 

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@
 |---|---|
 | `.csmlog` 日志支持 | 语法高亮、Hover 悬停提示、Outline 大纲、**智能重复折叠**、自动编码识别 |
 | `.lvcsm` 配置文件支持 | 语法高亮、Outline 大纲、自动编码识别 |
-| `CSM Modules` 模块管理 | 侧边栏浏览、搜索、引入、更新、移除 CSM 模块，支持 GitHub 登录与批量操作 |
+| `CSM Modules` 模块管理 | 侧边栏浏览、搜索、引入、更新、移除 CSM 模块，支持 GitHub 登录、批量操作，以及将模块放置到模块根目录或嵌套命名空间 |
 | 文件装饰 (File Decorations) | 为 `.csmlog` (C) 与 `.lvcsm` (L) 添加 Badge 标记，可与任意图标主题共存 |
 | 本地化 | 中文 / 英文界面切换 |
 
@@ -21,6 +21,7 @@
 - 打开任意 `.csmlog` 或 `.lvcsm` 文件即可自动激活扩展功能
 - `.csmlog` 文件中的重复日志行会自动检测并折叠，可配置阈值与样式
 - 打开侧边栏 **CSM Modules** 视图即可浏览和管理模块
+- 应用模块时可选择直接放到模块根目录，或放入已有/新的嵌套命名空间路径
 - 扩展自动为 `.csmlog` / `.lvcsm` 文件添加 Badge 标记，无需手动设置
 
 ## 扩展设置
@@ -28,6 +29,8 @@
 | 设置项 | 默认值 | 说明 |
 |---|---|---|
 | `csmModules.defaultModuleRoot` | `csm` | 首次引入模块时预填的默认目录名 |
+| `csmModules.moduleScanMaxDepth` | `3` | 递归发现本地模块候选目录时允许的最大深度 |
+| `csmModules.moduleScanIncludeReadmeWeakSignal` | `true` | 启用 README 弱信号后，包含 README 且至少有一个非文档文件的目录也可被识别为模块候选 |
 | `csmModules.hiddenTopics` | `csm-modsets`, `lv-csm-app`, `labview-csm`, `labview` | 侧边栏中默认隐藏的 topic |
 | `csmlog.folding.minRepeatCount` | `3` | 最少连续重复几次触发折叠 |
 | `csmlog.folding.maxBlockLines` | `20` | 多行块匹配的最大行数 |

--- a/README.md
+++ b/README.md
@@ -27,17 +27,17 @@
 
 ## 扩展设置
 
-| 设置项                                         | 默认值                                                | 说明                                                                              |
-|------------------------------------------------|-------------------------------------------------------|-----------------------------------------------------------------------------------|
-| `csmModules.defaultModuleRoot`                 | `csm`                                                 | 首次引入模块时预填的默认目录名                                                    |
-| `csmModules.moduleScanMaxDepth`                | `3`                                                   | 递归发现本地模块候选目录时允许的最大深度                                          |
-| `csmModules.moduleScanIncludeReadmeWeakSignal` | `true`                                                | 启用 README 弱信号后，包含 README 且至少有一个非文档文件的目录也可被识别为模块候选 |
-| `csmModules.moduleScanExcludedDirectories`     | `.git`, `node_modules`, `dist`, `build`, `out`, `tmp`, `docs`, `images` | 递归发现本地模块候选时跳过的目录名（大小写不敏感） |
-| `csmModules.hiddenTopics`                      | `csm-modsets`, `lv-csm-app`, `labview-csm`, `labview` | 侧边栏中默认隐藏的 topic                                                          |
-| `csmlog.folding.minRepeatCount`                | `3`                                                   | 最少连续重复几次触发折叠                                                          |
-| `csmlog.folding.maxBlockLines`                 | `20`                                                  | 多行块匹配的最大行数                                                              |
-| `csmlog.folding.smartParams`                   | `true`                                                | 启用参数归一化，消息模板相同仅参数不同的行也折叠                                   |
-| `csmlog.folding.decorationStyle`               | `compact`                                             | 折叠概要标签样式（compact: ×42 / detailed: 含时间）                                 |
+| 设置项                                         | 默认值                                                                  | 说明                                                                              |
+|------------------------------------------------|-------------------------------------------------------------------------|-----------------------------------------------------------------------------------|
+| `csmModules.defaultModuleRoot`                 | `csm`                                                                   | 首次引入模块时预填的默认目录名                                                    |
+| `csmModules.moduleScanMaxDepth`                | `3`                                                                     | 递归发现本地模块候选目录时允许的最大深度                                          |
+| `csmModules.moduleScanIncludeReadmeWeakSignal` | `true`                                                                  | 启用 README 弱信号后，包含 README 且至少有一个非文档文件的目录也可被识别为模块候选 |
+| `csmModules.moduleScanExcludedDirectories`     | `.git`, `node_modules`, `dist`, `build`, `out`, `tmp`, `docs`, `images` | 递归发现本地模块候选时跳过的目录名（大小写不敏感）                                  |
+| `csmModules.hiddenTopics`                      | `csm-modsets`, `lv-csm-app`, `labview-csm`, `labview`                   | 侧边栏中默认隐藏的 topic                                                          |
+| `csmlog.folding.minRepeatCount`                | `3`                                                                     | 最少连续重复几次触发折叠                                                          |
+| `csmlog.folding.maxBlockLines`                 | `20`                                                                    | 多行块匹配的最大行数                                                              |
+| `csmlog.folding.smartParams`                   | `true`                                                                  | 启用参数归一化，消息模板相同仅参数不同的行也折叠                                   |
+| `csmlog.folding.decorationStyle`               | `compact`                                                               | 折叠概要标签样式（compact: ×42 / detailed: 含时间）                                 |
 
 ## 更多文档
 

--- a/README.md
+++ b/README.md
@@ -22,6 +22,7 @@
 - `.csmlog` 文件中的重复日志行会自动检测并折叠，可配置阈值与样式
 - 打开侧边栏 **CSM Modules** 视图即可浏览和管理模块
 - 应用模块时可选择直接放到模块根目录，或放入已有/新的嵌套命名空间路径
+- 已确认管理的模块目录不会参与后续递归扫描，避免其内部内容被误识别为候选
 - 扩展自动为 `.csmlog` / `.lvcsm` 文件添加 Badge 标记，无需手动设置
 
 ## 扩展设置
@@ -31,6 +32,7 @@
 | `csmModules.defaultModuleRoot`                 | `csm`                                                 | 首次引入模块时预填的默认目录名                                                    |
 | `csmModules.moduleScanMaxDepth`                | `3`                                                   | 递归发现本地模块候选目录时允许的最大深度                                          |
 | `csmModules.moduleScanIncludeReadmeWeakSignal` | `true`                                                | 启用 README 弱信号后，包含 README 且至少有一个非文档文件的目录也可被识别为模块候选 |
+| `csmModules.moduleScanExcludedDirectories`     | `.git`, `node_modules`, `dist`, `build`, `out`, `tmp`, `docs`, `images` | 递归发现本地模块候选时跳过的目录名（大小写不敏感） |
 | `csmModules.hiddenTopics`                      | `csm-modsets`, `lv-csm-app`, `labview-csm`, `labview` | 侧边栏中默认隐藏的 topic                                                          |
 | `csmlog.folding.minRepeatCount`                | `3`                                                   | 最少连续重复几次触发折叠                                                          |
 | `csmlog.folding.maxBlockLines`                 | `20`                                                  | 多行块匹配的最大行数                                                              |

--- a/docs/module-management.md
+++ b/docs/module-management.md
@@ -75,10 +75,10 @@
 
 ## 扩展设置
 
-| 设置项 | 默认值 | 说明 |
-|---|---|---|
-| `csmModules.defaultModuleRoot` | `csm` | 用于新仓库首次初始化 / 首次应用模块时预填模块根目录 |
-| `csmModules.moduleScanMaxDepth` | `3` | 控制递归发现本地模块候选目录时允许的最大深度 |
+| 设置项                                         | 默认值 | 说明                                                                |
+|------------------------------------------------|--------|---------------------------------------------------------------------|
+| `csmModules.defaultModuleRoot`                 | `csm`  | 用于新仓库首次初始化 / 首次应用模块时预填模块根目录                 |
+| `csmModules.moduleScanMaxDepth`                | `3`    | 控制递归发现本地模块候选目录时允许的最大深度                        |
 | `csmModules.moduleScanIncludeReadmeWeakSignal` | `true` | 启用后，包含 README 且至少有一个非文档文件的目录也会被识别为模块候选 |
 
 ## 缓存策略

--- a/docs/module-management.md
+++ b/docs/module-management.md
@@ -62,6 +62,8 @@
 
 - 默认会递归扫描模块根目录下的候选目录，最大深度由 `csmModules.moduleScanMaxDepth` 控制（默认 `3`）
 - 若启用 `csmModules.moduleScanIncludeReadmeWeakSignal`，包含 README 且至少有一个非文档文件的目录也会被视为模块候选，便于识别更宽松的本地模块布局
+- 已管理模块目录会被整体跳过：扫描不会深入已确认管理的模块内部，避免把模块内部内容误识别为候选
+- 默认跳过一组常见构建/依赖目录（`.git`、`node_modules`、`dist`、`build`、`out`、`tmp`、`docs`、`images`），可通过 `csmModules.moduleScanExcludedDirectories` 调整
 
 ## 本地模块配置
 
@@ -80,6 +82,7 @@
 | `csmModules.defaultModuleRoot`                 | `csm`  | 用于新仓库首次初始化 / 首次应用模块时预填模块根目录                 |
 | `csmModules.moduleScanMaxDepth`                | `3`    | 控制递归发现本地模块候选目录时允许的最大深度                        |
 | `csmModules.moduleScanIncludeReadmeWeakSignal` | `true` | 启用后，包含 README 且至少有一个非文档文件的目录也会被识别为模块候选 |
+| `csmModules.moduleScanExcludedDirectories`     | `.git`, `node_modules`, `dist`, `build`, `out`, `tmp`, `docs`, `images` | 递归发现本地模块候选时跳过的目录名（大小写不敏感） |
 
 ## 缓存策略
 

--- a/docs/module-management.md
+++ b/docs/module-management.md
@@ -2,7 +2,7 @@
 
 ## 功能概述
 
-侧边栏 `CSM Modules` 容器现在只保留一个原生视图。当前工作区中的已管理模块、未管理文件夹与 GitHub 模块目录会在同一个 Webview 卡片列表中统一显示；本地项目条目固定排在前面，远端目录条目跟在后面。模块可通过 `submodule` 或 `copy` 方式引入本地仓库，并通过本地 YAML 配置文件记录已应用模块。
+侧边栏 `CSM Modules` 容器现在只保留一个原生视图。当前工作区中的已管理模块、未管理文件夹与 GitHub 模块目录会在同一个 Webview 卡片列表中统一显示；本地项目条目固定排在前面，远端目录条目跟在后面。模块可通过 `submodule` 或 `copy` 方式引入本地仓库，并通过本地 YAML 配置文件记录已应用模块。应用模块时，扩展会提示选择模块根目录下的放置位置：可直接落在根目录，也可使用已有或新建的嵌套命名空间路径。
 
 ## 功能特性
 
@@ -28,6 +28,7 @@
 ### 模块操作
 
 - 支持勾选多选模块；存在勾选模块时，可从视图标题栏执行 `Apply Selected` 批量应用
+- 应用模块时会提示选择命名空间位置：可直接使用模块根目录，也可选择最近使用的命名空间或手动输入新的嵌套路径；新建的命名空间会被记住，供后续复用
 - 模块卡片支持 VS Code 原生右键菜单，可直接执行 `Apply` / `Update` / `Remove` / `Open README` / 选择操作，并按模块当前状态自动启用、禁用或切换对应项
 - 首次应用时可初始化本地模块目录，默认生成 `csm/csm-modules.yaml`，也可指定仓库内自定义相对路径
 - 支持 `submodule` / `copy` 两种引入方式
@@ -57,6 +58,11 @@
 - 若仓库检测到 `csm/` 目录与 `*.lvproj`，但尚未存在本地模块配置，打开侧边栏时会主动提醒初始化，并在标题栏显示 `Initialize Workspace Management` 工具按钮
 - 若仓库内已存在 `csm/` 目录且包含已初始化的 submodule，但尚未存在配置文件，扩展会自动反向生成 `csm/csm-modules.yaml`
 
+## 模块扫描与发现
+
+- 默认会递归扫描模块根目录下的候选目录，最大深度由 `csmModules.moduleScanMaxDepth` 控制（默认 `3`）
+- 若启用 `csmModules.moduleScanIncludeReadmeWeakSignal`，包含 README 且至少有一个非文档文件的目录也会被视为模块候选，便于识别更宽松的本地模块布局
+
 ## 本地模块配置
 
 - **默认初始化目录**：`csm/`（可通过 `csmModules.defaultModuleRoot` 修改新仓库首次初始化时的默认值）
@@ -72,6 +78,8 @@
 | 设置项 | 默认值 | 说明 |
 |---|---|---|
 | `csmModules.defaultModuleRoot` | `csm` | 用于新仓库首次初始化 / 首次应用模块时预填模块根目录 |
+| `csmModules.moduleScanMaxDepth` | `3` | 控制递归发现本地模块候选目录时允许的最大深度 |
+| `csmModules.moduleScanIncludeReadmeWeakSignal` | `true` | 启用后，包含 README 且至少有一个非文档文件的目录也会被识别为模块候选 |
 
 ## 缓存策略
 

--- a/docs/module-management.md
+++ b/docs/module-management.md
@@ -77,12 +77,12 @@
 
 ## 扩展设置
 
-| 设置项                                         | 默认值 | 说明                                                                |
-|------------------------------------------------|--------|---------------------------------------------------------------------|
-| `csmModules.defaultModuleRoot`                 | `csm`  | 用于新仓库首次初始化 / 首次应用模块时预填模块根目录                 |
-| `csmModules.moduleScanMaxDepth`                | `3`    | 控制递归发现本地模块候选目录时允许的最大深度                        |
-| `csmModules.moduleScanIncludeReadmeWeakSignal` | `true` | 启用后，包含 README 且至少有一个非文档文件的目录也会被识别为模块候选 |
-| `csmModules.moduleScanExcludedDirectories`     | `.git`, `node_modules`, `dist`, `build`, `out`, `tmp`, `docs`, `images` | 递归发现本地模块候选时跳过的目录名（大小写不敏感） |
+| 设置项                                         | 默认值                                                                  | 说明                                                                |
+|------------------------------------------------|-------------------------------------------------------------------------|---------------------------------------------------------------------|
+| `csmModules.defaultModuleRoot`                 | `csm`                                                                   | 用于新仓库首次初始化 / 首次应用模块时预填模块根目录                 |
+| `csmModules.moduleScanMaxDepth`                | `3`                                                                     | 控制递归发现本地模块候选目录时允许的最大深度                        |
+| `csmModules.moduleScanIncludeReadmeWeakSignal` | `true`                                                                  | 启用后，包含 README 且至少有一个非文档文件的目录也会被识别为模块候选 |
+| `csmModules.moduleScanExcludedDirectories`     | `.git`, `node_modules`, `dist`, `build`, `out`, `tmp`, `docs`, `images` | 递归发现本地模块候选时跳过的目录名（大小写不敏感）                    |
 
 ## 缓存策略
 

--- a/docs/user-guide.md
+++ b/docs/user-guide.md
@@ -2,7 +2,7 @@
 
 ## 安装要求
 
-- Visual Studio Code 1.60.0 或更高版本
+- Visual Studio Code 1.63.0 或更高版本
 
 ## 支持内容
 
@@ -14,6 +14,7 @@
 ## 模块管理入口
 
 - 打开侧边栏 `CSM Modules` 即可浏览当前工作区模块、未管理文件夹和 GitHub 模块目录
+- 应用模块时可选择直接放入模块根目录，或放入已有/新的嵌套命名空间路径
 - 需要更完整的模块管理说明时，请参阅 [`module-management.md`](module-management.md)
 
 ## 扩展设置
@@ -21,6 +22,8 @@
 | 设置项 | 默认值 | 说明 |
 |---|---|---|
 | `csmModules.defaultModuleRoot` | `csm` | 首次引入模块时预填的默认目录名 |
+| `csmModules.moduleScanMaxDepth` | `3` | 递归发现本地模块候选目录时允许的最大深度 |
+| `csmModules.moduleScanIncludeReadmeWeakSignal` | `true` | 启用 README 弱信号后，包含 README 且至少有一个非文档文件的目录也可被识别为模块候选 |
 
 ## 文件装饰与标记
 

--- a/docs/user-guide.md
+++ b/docs/user-guide.md
@@ -19,10 +19,10 @@
 
 ## 扩展设置
 
-| 设置项 | 默认值 | 说明 |
-|---|---|---|
-| `csmModules.defaultModuleRoot` | `csm` | 首次引入模块时预填的默认目录名 |
-| `csmModules.moduleScanMaxDepth` | `3` | 递归发现本地模块候选目录时允许的最大深度 |
+| 设置项                                         | 默认值 | 说明                                                                              |
+|------------------------------------------------|--------|-----------------------------------------------------------------------------------|
+| `csmModules.defaultModuleRoot`                 | `csm`  | 首次引入模块时预填的默认目录名                                                    |
+| `csmModules.moduleScanMaxDepth`                | `3`    | 递归发现本地模块候选目录时允许的最大深度                                          |
 | `csmModules.moduleScanIncludeReadmeWeakSignal` | `true` | 启用 README 弱信号后，包含 README 且至少有一个非文档文件的目录也可被识别为模块候选 |
 
 ## 文件装饰与标记

--- a/docs/user-guide.md
+++ b/docs/user-guide.md
@@ -20,12 +20,12 @@
 
 ## 扩展设置
 
-| 设置项                                         | 默认值 | 说明                                                                              |
-|------------------------------------------------|--------|-----------------------------------------------------------------------------------|
-| `csmModules.defaultModuleRoot`                 | `csm`  | 首次引入模块时预填的默认目录名                                                    |
-| `csmModules.moduleScanMaxDepth`                | `3`    | 递归发现本地模块候选目录时允许的最大深度                                          |
-| `csmModules.moduleScanIncludeReadmeWeakSignal` | `true` | 启用 README 弱信号后，包含 README 且至少有一个非文档文件的目录也可被识别为模块候选 |
-| `csmModules.moduleScanExcludedDirectories`     | `.git`, `node_modules`, `dist`, `build`, `out`, `tmp`, `docs`, `images` | 递归发现本地模块候选时跳过的目录名（大小写不敏感） |
+| 设置项                                         | 默认值                                                                  | 说明                                                                              |
+|------------------------------------------------|-------------------------------------------------------------------------|-----------------------------------------------------------------------------------|
+| `csmModules.defaultModuleRoot`                 | `csm`                                                                   | 首次引入模块时预填的默认目录名                                                    |
+| `csmModules.moduleScanMaxDepth`                | `3`                                                                     | 递归发现本地模块候选目录时允许的最大深度                                          |
+| `csmModules.moduleScanIncludeReadmeWeakSignal` | `true`                                                                  | 启用 README 弱信号后，包含 README 且至少有一个非文档文件的目录也可被识别为模块候选 |
+| `csmModules.moduleScanExcludedDirectories`     | `.git`, `node_modules`, `dist`, `build`, `out`, `tmp`, `docs`, `images` | 递归发现本地模块候选时跳过的目录名（大小写不敏感）                                  |
 
 ## 文件装饰与标记
 

--- a/docs/user-guide.md
+++ b/docs/user-guide.md
@@ -15,6 +15,7 @@
 
 - 打开侧边栏 `CSM Modules` 即可浏览当前工作区模块、未管理文件夹和 GitHub 模块目录
 - 应用模块时可选择直接放入模块根目录，或放入已有/新的嵌套命名空间路径
+- 已确认管理的模块目录不会参与后续递归扫描，避免其内部内容被误识别为候选
 - 需要更完整的模块管理说明时，请参阅 [`module-management.md`](module-management.md)
 
 ## 扩展设置
@@ -24,6 +25,7 @@
 | `csmModules.defaultModuleRoot`                 | `csm`  | 首次引入模块时预填的默认目录名                                                    |
 | `csmModules.moduleScanMaxDepth`                | `3`    | 递归发现本地模块候选目录时允许的最大深度                                          |
 | `csmModules.moduleScanIncludeReadmeWeakSignal` | `true` | 启用 README 弱信号后，包含 README 且至少有一个非文档文件的目录也可被识别为模块候选 |
+| `csmModules.moduleScanExcludedDirectories`     | `.git`, `node_modules`, `dist`, `build`, `out`, `tmp`, `docs`, `images` | 递归发现本地模块候选时跳过的目录名（大小写不敏感） |
 
 ## 文件装饰与标记
 

--- a/package.json
+++ b/package.json
@@ -326,18 +326,33 @@
           "order": 1,
           "description": "%configuration.csmModules.defaultModuleRoot.description%"
         },
+        "csmModules.moduleScanMaxDepth": {
+          "type": "number",
+          "default": 3,
+          "minimum": 1,
+          "scope": "resource",
+          "order": 2,
+          "description": "%configuration.csmModules.moduleScanMaxDepth.description%"
+        },
+        "csmModules.moduleScanIncludeReadmeWeakSignal": {
+          "type": "boolean",
+          "default": true,
+          "scope": "resource",
+          "order": 3,
+          "description": "%configuration.csmModules.moduleScanIncludeReadmeWeakSignal.description%"
+        },
         "csmModules.autoStarCsmCore": {
           "type": "boolean",
           "default": true,
           "scope": "window",
-          "order": 2,
+          "order": 4,
           "description": "%configuration.csmModules.autoStarCsmCore.description%"
         },
         "csmModules.autoStarModuleRepo": {
           "type": "boolean",
           "default": true,
           "scope": "window",
-          "order": 3,
+          "order": 5,
           "description": "%configuration.csmModules.autoStarModuleRepo.description%"
         },
         "csmModules.hiddenTopics": {

--- a/package.json
+++ b/package.json
@@ -341,18 +341,37 @@
           "order": 3,
           "description": "%configuration.csmModules.moduleScanIncludeReadmeWeakSignal.description%"
         },
+        "csmModules.moduleScanExcludedDirectories": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "default": [
+            ".git",
+            "node_modules",
+            "dist",
+            "build",
+            "out",
+            "tmp",
+            "docs",
+            "images"
+          ],
+          "scope": "resource",
+          "order": 4,
+          "description": "%configuration.csmModules.moduleScanExcludedDirectories.description%"
+        },
         "csmModules.autoStarCsmCore": {
           "type": "boolean",
           "default": true,
           "scope": "window",
-          "order": 4,
+          "order": 5,
           "description": "%configuration.csmModules.autoStarCsmCore.description%"
         },
         "csmModules.autoStarModuleRepo": {
           "type": "boolean",
           "default": true,
           "scope": "window",
-          "order": 5,
+          "order": 6,
           "description": "%configuration.csmModules.autoStarModuleRepo.description%"
         },
         "csmModules.hiddenTopics": {

--- a/package.nls.json
+++ b/package.nls.json
@@ -26,6 +26,7 @@
   "configuration.csmModules.defaultModuleRoot.description": "Default relative directory used when initializing local CSM module management for a repository that does not already have a csm-modules.yaml file.",
   "configuration.csmModules.moduleScanMaxDepth.description": "Maximum directory depth (relative to the module root) used when recursively discovering module candidates in the local workspace.",
   "configuration.csmModules.moduleScanIncludeReadmeWeakSignal.description": "Include README-based weak signals during recursive module discovery. When enabled, a folder with README plus at least one non-document file can be treated as a module candidate.",
+  "configuration.csmModules.moduleScanExcludedDirectories.description": "Directory names to skip (case-insensitively, at any depth) when recursively discovering module candidates in the local workspace. Existing managed module folders are always skipped regardless of this setting.",
   "configuration.csmModules.hiddenTopics.description": "Module repository topics to hide from the CSM Modules sidebar badges, tree tooltips, and local search text.",
   "configuration.csmModules.autoStarCsmCore.description": "Automatically star the CSM Core repository (NEVSTOP-LAB/Communicable-State-Machine) on GitHub when applying modules to the local workspace.",
   "configuration.csmModules.autoStarModuleRepo.description": "Automatically star the downloaded module repository on GitHub when applying it to the local workspace.",

--- a/package.nls.json
+++ b/package.nls.json
@@ -24,6 +24,8 @@
   "csmModules.title": "CSM Modules",
   "views.csmModules.view.name": "Available Modules",
   "configuration.csmModules.defaultModuleRoot.description": "Default relative directory used when initializing local CSM module management for a repository that does not already have a csm-modules.yaml file.",
+  "configuration.csmModules.moduleScanMaxDepth.description": "Maximum directory depth (relative to the module root) used when recursively discovering module candidates in the local workspace.",
+  "configuration.csmModules.moduleScanIncludeReadmeWeakSignal.description": "Include README-based weak signals during recursive module discovery. When enabled, a folder with README plus at least one non-document file can be treated as a module candidate.",
   "configuration.csmModules.hiddenTopics.description": "Module repository topics to hide from the CSM Modules sidebar badges, tree tooltips, and local search text.",
   "configuration.csmModules.autoStarCsmCore.description": "Automatically star the CSM Core repository (NEVSTOP-LAB/Communicable-State-Machine) on GitHub when applying modules to the local workspace.",
   "configuration.csmModules.autoStarModuleRepo.description": "Automatically star the downloaded module repository on GitHub when applying it to the local workspace.",

--- a/package.nls.zh-cn.json
+++ b/package.nls.zh-cn.json
@@ -26,8 +26,7 @@
   "configuration.csmModules.defaultModuleRoot.description": "当仓库中尚不存在 csm-modules.yaml 文件时，用于初始化本地 CSM 模块管理的默认相对目录。",
   "configuration.csmModules.moduleScanMaxDepth.description": "在本地工作区递归发现模块候选目录时使用的最大扫描深度（相对于模块根目录）。",
   "configuration.csmModules.moduleScanIncludeReadmeWeakSignal.description": "是否在递归发现时启用 README 弱信号。启用后，包含 README 且至少有一个非文档文件的目录可被识别为模块候选。",
-  "configuration.csmModules.moduleScanExcludedDirectories.description": "在本地工作区递归发现模块候选目录时跳过的目录名（大小写不敏感，任意层级匹配）。已管理的模块目录始终会被跳过，不受此设置影响。"
-  "configuration.csmModules.hiddenTopics.description": "用于配置在 CSM Modules 侧边栏徽标、树视图提示和本地搜索文本中隐藏的模块仓库 topics。",
+  "configuration.csmModules.moduleScanExcludedDirectories.description": "在本地工作区递归发现模块候选目录时跳过的目录名（大小写不敏感，任意层级匹配）。已管理的模块目录始终会被跳过，不受此设置影响。""configuration.csmModules.hiddenTopics.description": "用于配置在 CSM Modules 侧边栏徽标、树视图提示和本地搜索文本中隐藏的模块仓库 topics。",
   "configuration.csmModules.autoStarCsmCore.description": "将模块应用到本地工作区时，自动在 GitHub 上 Star CSM Core 仓库（NEVSTOP-LAB/Communicable-State-Machine）。",
   "configuration.csmModules.autoStarModuleRepo.description": "将模块应用到本地工作区时，自动在 GitHub 上 Star 所下载模块对应的仓库。",
   "configuration.csmModules.hideArchivedRepos.description": "在可用模块列表中隐藏已归档的模块仓库。关闭后，已归档的仓库将与活跃仓库一同显示。",

--- a/package.nls.zh-cn.json
+++ b/package.nls.zh-cn.json
@@ -24,6 +24,8 @@
   "csmModules.title": "CSM 模块",
   "views.csmModules.view.name": "可用模块",
   "configuration.csmModules.defaultModuleRoot.description": "当仓库中尚不存在 csm-modules.yaml 文件时，用于初始化本地 CSM 模块管理的默认相对目录。",
+  "configuration.csmModules.moduleScanMaxDepth.description": "在本地工作区递归发现模块候选目录时使用的最大扫描深度（相对于模块根目录）。",
+  "configuration.csmModules.moduleScanIncludeReadmeWeakSignal.description": "是否在递归发现时启用 README 弱信号。启用后，包含 README 且至少有一个非文档文件的目录可被识别为模块候选。",
   "configuration.csmModules.hiddenTopics.description": "用于配置在 CSM Modules 侧边栏徽标、树视图提示和本地搜索文本中隐藏的模块仓库 topics。",
   "configuration.csmModules.autoStarCsmCore.description": "将模块应用到本地工作区时，自动在 GitHub 上 Star CSM Core 仓库（NEVSTOP-LAB/Communicable-State-Machine）。",
   "configuration.csmModules.autoStarModuleRepo.description": "将模块应用到本地工作区时，自动在 GitHub 上 Star 所下载模块对应的仓库。",

--- a/package.nls.zh-cn.json
+++ b/package.nls.zh-cn.json
@@ -26,6 +26,7 @@
   "configuration.csmModules.defaultModuleRoot.description": "当仓库中尚不存在 csm-modules.yaml 文件时，用于初始化本地 CSM 模块管理的默认相对目录。",
   "configuration.csmModules.moduleScanMaxDepth.description": "在本地工作区递归发现模块候选目录时使用的最大扫描深度（相对于模块根目录）。",
   "configuration.csmModules.moduleScanIncludeReadmeWeakSignal.description": "是否在递归发现时启用 README 弱信号。启用后，包含 README 且至少有一个非文档文件的目录可被识别为模块候选。",
+  "configuration.csmModules.moduleScanExcludedDirectories.description": "在本地工作区递归发现模块候选目录时跳过的目录名（大小写不敏感，任意层级匹配）。已管理的模块目录始终会被跳过，不受此设置影响。"
   "configuration.csmModules.hiddenTopics.description": "用于配置在 CSM Modules 侧边栏徽标、树视图提示和本地搜索文本中隐藏的模块仓库 topics。",
   "configuration.csmModules.autoStarCsmCore.description": "将模块应用到本地工作区时，自动在 GitHub 上 Star CSM Core 仓库（NEVSTOP-LAB/Communicable-State-Machine）。",
   "configuration.csmModules.autoStarModuleRepo.description": "将模块应用到本地工作区时，自动在 GitHub 上 Star 所下载模块对应的仓库。",

--- a/src/modules/cacheStore.ts
+++ b/src/modules/cacheStore.ts
@@ -10,6 +10,7 @@ const MODULE_ETAG_KEY = STORAGE_KEYS.moduleEtag;
 const MODULE_AUTH_KEY = STORAGE_KEYS.moduleAuth;
 const MODULE_SORT_STATE_KEY = STORAGE_KEYS.moduleSortState;
 const MODULE_LV_VERSION_KEY = STORAGE_KEYS.moduleLvVersion;
+const RECENT_NAMESPACE_BY_WORKSPACE_KEY = STORAGE_KEYS.recentNamespaceByWorkspace;
 const MODULE_CACHE_SCHEMA_VERSION = 1;
 
 function isModuleSnapshotShape(value: unknown): value is ModuleCacheSnapshot {
@@ -154,6 +155,18 @@ export class ModuleCacheStore {
 		await this.globalState.update(MODULE_LV_VERSION_KEY, cache);
 	}
 
+	public getRecentNamespaceByWorkspace(): Record<string, string> {
+		const value = this.globalState.get<unknown>(RECENT_NAMESPACE_BY_WORKSPACE_KEY);
+		if (!value || typeof value !== 'object' || Array.isArray(value)) {
+			return {};
+		}
+		return value as Record<string, string>;
+	}
+
+	public async setRecentNamespaceByWorkspace(cache: Record<string, string>): Promise<void> {
+		await this.globalState.update(RECENT_NAMESPACE_BY_WORKSPACE_KEY, cache);
+	}
+
 	public async clear(): Promise<void> {
 		await this.globalState.update(MODULE_CACHE_KEY, undefined);
 		await this.globalState.update(README_CACHE_KEY, undefined);
@@ -161,5 +174,6 @@ export class ModuleCacheStore {
 		await this.globalState.update(MODULE_AUTH_KEY, undefined);
 		await this.globalState.update(MODULE_SORT_STATE_KEY, undefined);
 		await this.globalState.update(MODULE_LV_VERSION_KEY, undefined);
+		await this.globalState.update(RECENT_NAMESPACE_BY_WORKSPACE_KEY, undefined);
 	}
 }

--- a/src/modules/constants.ts
+++ b/src/modules/constants.ts
@@ -37,7 +37,7 @@ export const CONFIG_SECTIONS = {
 export const CONFIG_KEYS = {
 	defaultModuleRoot: 'defaultModuleRoot',
 	moduleScanMaxDepth: 'moduleScanMaxDepth',
-	moduleScanIncludeReadmeWeakSignal: 'moduleScanIncludeReadmeWeakSignal',	moduleScanExcludedDirectories: 'moduleScanExcludedDirectories',	hiddenTopics: 'hiddenTopics',
+	moduleScanIncludeReadmeWeakSignal: 'moduleScanIncludeReadmeWeakSignal', moduleScanExcludedDirectories: 'moduleScanExcludedDirectories', hiddenTopics: 'hiddenTopics',
 	autoStarCsmCore: 'autoStarCsmCore',
 	autoStarModuleRepo: 'autoStarModuleRepo',
 	hideArchivedRepos: 'hideArchivedRepos',

--- a/src/modules/constants.ts
+++ b/src/modules/constants.ts
@@ -37,8 +37,7 @@ export const CONFIG_SECTIONS = {
 export const CONFIG_KEYS = {
 	defaultModuleRoot: 'defaultModuleRoot',
 	moduleScanMaxDepth: 'moduleScanMaxDepth',
-	moduleScanIncludeReadmeWeakSignal: 'moduleScanIncludeReadmeWeakSignal',
-	hiddenTopics: 'hiddenTopics',
+	moduleScanIncludeReadmeWeakSignal: 'moduleScanIncludeReadmeWeakSignal',	moduleScanExcludedDirectories: 'moduleScanExcludedDirectories',	hiddenTopics: 'hiddenTopics',
 	autoStarCsmCore: 'autoStarCsmCore',
 	autoStarModuleRepo: 'autoStarModuleRepo',
 	hideArchivedRepos: 'hideArchivedRepos',

--- a/src/modules/constants.ts
+++ b/src/modules/constants.ts
@@ -36,6 +36,8 @@ export const CONFIG_SECTIONS = {
 
 export const CONFIG_KEYS = {
 	defaultModuleRoot: 'defaultModuleRoot',
+	moduleScanMaxDepth: 'moduleScanMaxDepth',
+	moduleScanIncludeReadmeWeakSignal: 'moduleScanIncludeReadmeWeakSignal',
 	hiddenTopics: 'hiddenTopics',
 	autoStarCsmCore: 'autoStarCsmCore',
 	autoStarModuleRepo: 'autoStarModuleRepo',
@@ -52,6 +54,7 @@ export const STORAGE_KEYS = {
 	moduleAuth: 'csmModules.auth.lastKnown',
 	moduleSortState: 'csmModules.sort.state',
 	moduleLvVersion: 'csmModules.cache.lvVersions',
+	recentNamespaceByWorkspace: 'csmModules.cache.recentNamespaceByWorkspace',
 } as const;
 
 export const CONTEXT_KEYS = {

--- a/src/modules/messages.ts
+++ b/src/modules/messages.ts
@@ -807,12 +807,12 @@ const messages = {
 		zh: '未管理文件夹',
 	},
 	workspaceModulesEmptyTitle: {
-		en: 'No module folders found under {root}/',
-		zh: '在 {root}/ 下未发现模块文件夹',
+		en: 'No module candidates found under {root}/',
+		zh: '在 {root}/ 下未发现模块候选目录',
 	},
 	workspaceModulesEmptyBody: {
-		en: 'This workspace does not currently contain module folders in the configured local module root.',
-		zh: '当前工作区在已配置的本地模块根目录下还没有模块文件夹。',
+		en: 'This workspace does not currently contain detectable module candidate folders in the configured local module root.',
+		zh: '当前工作区在已配置的本地模块根目录下还没有可识别的模块候选目录。',
 	},
 	managedBadge: {
 		en: 'Managed',
@@ -877,6 +877,46 @@ const messages = {
 	tipBody: {
 		en: 'Use the checkboxes to build a selection, then apply modules from the toolbar or open individual README files from each card.',
 		zh: '使用复选框建立选择，然后可从工具栏应用模块，或从每张卡片打开对应的 README。',
+	},
+	applyNamespacePlaceholder: {
+		en: 'Choose where to place the selected modules under the local module root.',
+		zh: '选择要在本地模块根目录下放置所选模块的位置。',
+	},
+	applyNamespaceRootOption: {
+		en: 'Use {root}/ directly',
+		zh: '直接使用 {root}/',
+	},
+	applyNamespaceRootDetail: {
+		en: 'Modules will be placed directly under {root}/<module-name>.',
+		zh: '模块将直接放置到 {root}/<module-name>。',
+	},
+	applyNamespacePathDetail: {
+		en: 'Target namespace path: {path}',
+		zh: '目标命名空间路径：{path}',
+	},
+	applyNamespaceManualInput: {
+		en: 'Enter a new namespace path...',
+		zh: '输入新的命名空间路径...',
+	},
+	applyNamespaceManualInputDetail: {
+		en: 'Create or use a custom path under the module root (for example: HAL/niDMM).',
+		zh: '在模块根目录下创建或使用自定义路径（例如：HAL/niDMM）。',
+	},
+	applyNamespaceInputPrompt: {
+		en: 'Enter a namespace path relative to {root}/ (leave empty to use root directly).',
+		zh: '请输入相对于 {root}/ 的命名空间路径（留空表示直接使用根目录）。',
+	},
+	applyNamespaceCreateConfirm: {
+		en: 'Namespace path {path} does not exist yet. Create it now?',
+		zh: '命名空间路径 {path} 尚不存在。要立即创建吗？',
+	},
+	applyNamespaceCreateAction: {
+		en: 'Create Namespace',
+		zh: '创建命名空间',
+	},
+	applyNamespaceTip: {
+		en: 'Tip: created namespace path {path}. You can reuse it next time from the namespace selector.',
+		zh: '提示：已创建命名空间路径 {path}。下次可在命名空间选择器中直接复用。',
 	},
 	dismissTip: {
 		en: 'Dismiss tip',

--- a/src/modules/moduleManagerController.ts
+++ b/src/modules/moduleManagerController.ts
@@ -26,6 +26,7 @@ const HAS_APPLIED_SELECTION_CONTEXT_KEY = CONTEXT_KEYS.selectionHasApplied;
 const HAS_UNAPPLIED_SELECTION_CONTEXT_KEY = CONTEXT_KEYS.selectionHasUnapplied;
 const LVPROJ_GLOB = '**/*.lvproj';
 const DEFAULT_SHARED_MODULE_TOPICS = ['labview-csm', 'csm-modsets'] as const;
+const ROOT_NAMESPACE_VALUE = '';
 
 function getWorkspaceInitPrompt(rootPath: string): string {
 	return t('workspaceInitPrompt', { rootPath });
@@ -49,6 +50,11 @@ type WebviewModuleContext = {
 
 type ApplyMethodQuickPickItem = vscode.QuickPickItem & {
 	method?: ModuleApplyMethod;
+};
+
+type NamespaceQuickPickItem = vscode.QuickPickItem & {
+	namespacePath?: string;
+	action?: 'manual';
 };
 
 type RepositoryVisibility = 'private' | 'public';
@@ -151,6 +157,7 @@ export class ModuleManagerController {
 	private currentAccountId: string | undefined;
 	private currentAccountLabel: string | undefined;
 	private lastTokenVerifiedAt = 0;
+	private recentNamespaceByWorkspace: Record<string, string>;
 	private static readonly TOKEN_VERIFY_INTERVAL_MS = 10 * 60 * 1000; // 10 minutes
 
 	constructor(private readonly context: vscode.ExtensionContext, deps: ModuleManagerControllerDeps = {}) {
@@ -162,6 +169,7 @@ export class ModuleManagerController {
 		this.cacheStore = new ModuleCacheStore(context.globalState);
 		this.readmeAssetCache = new ReadmeAssetCache(context.globalStorageUri);
 		this.currentSortState = this.cacheStore.getModuleSortState();
+		this.recentNamespaceByWorkspace = this.cacheStore.getRecentNamespaceByWorkspace();
 		// Pull any legacy in-memory copy from GlobalState (for backward compat),
 		// but do NOT persist new entries there going forward — the filesystem
 		// asset cache is the single source of truth (review item 3.5).
@@ -287,13 +295,25 @@ export class ModuleManagerController {
 			return;
 		}
 
-		const duplicateTargets = this.findDuplicateTargetPaths(config, selectedEntries);
+		const targetNamespace = await this.promptApplyTargetNamespace(workspaceFolder, applyRoot, config);
+		if (typeof targetNamespace === 'undefined') {
+			return;
+		}
+		const explicitTargetPathsByModuleKey = new Map<string, string>();
+		for (const moduleEntry of selectedEntries) {
+			explicitTargetPathsByModuleKey.set(
+				this.getModuleKey(moduleEntry),
+				this.workspaceModuleService.getTargetRelativePath(config, moduleEntry, targetNamespace),
+			);
+		}
+
+		const duplicateTargets = this.findDuplicateTargetPaths(config, selectedEntries, explicitTargetPathsByModuleKey);
 		if (duplicateTargets.length > 0) {
 			void vscode.window.showErrorMessage(t('duplicateTargetPaths', { paths: duplicateTargets.join(', ') }));
 			return;
 		}
 
-		const occupiedTargets = await this.findOccupiedTargetPaths(applyRoot, config, selectedEntries);
+		const occupiedTargets = await this.findOccupiedTargetPaths(applyRoot, config, selectedEntries, explicitTargetPathsByModuleKey);
 		if (occupiedTargets.length > 0) {
 			const prefix = applyMethod === 'copy' ? t('copyTargetExists') : t('targetPathExists');
 			void vscode.window.showWarningMessage(`${prefix}: ${occupiedTargets.join(', ')}`);
@@ -334,6 +354,7 @@ export class ModuleManagerController {
 						// then atomically merge into config in one write (review item 2.4).
 						const settled = await Promise.allSettled(
 							selectedEntries.map(async (moduleEntry) => {
+								const explicitTargetPath = explicitTargetPathsByModuleKey.get(this.getModuleKey(moduleEntry));
 								try {
 									const applied = await this.workspaceModuleService.applyModule(
 										applyRoot,
@@ -342,6 +363,7 @@ export class ModuleManagerController {
 										applyMethod,
 										authToken,
 										(msg) => progress.report({ message: msg }),
+										explicitTargetPath,
 									);
 									return applied;
 								} finally {
@@ -377,6 +399,7 @@ export class ModuleManagerController {
 					} else {
 						// Submodule mode must run serially because git submodule add can race.
 						for (const moduleEntry of selectedEntries) {
+							const explicitTargetPath = explicitTargetPathsByModuleKey.get(this.getModuleKey(moduleEntry));
 							const applied = await this.workspaceModuleService.applyModule(
 								applyRoot,
 								config,
@@ -384,6 +407,7 @@ export class ModuleManagerController {
 								applyMethod,
 								authToken,
 								(msg) => progress.report({ message: msg }),
+								explicitTargetPath,
 							);
 							config = this.workspaceModuleService.withAppliedModule(config, applied);
 							await writeConfigSafely(config);
@@ -1065,11 +1089,12 @@ export class ModuleManagerController {
 		workspaceRoot: string,
 		folder: LocalUnmanagedFolderEntry,
 	): Promise<LocalModuleConfig> {
+		const defaultRoot = this.getConfiguredDefaultModuleRoot();
 		const normalizedFolderPath = this.workspaceModuleService.normalizeRootPath(folder.path);
 		const inferredRoot = path.posix.dirname(normalizedFolderPath);
-		const configRoot = inferredRoot === '.'
-			? this.getConfiguredDefaultModuleRoot()
-			: this.workspaceModuleService.normalizeRootPath(inferredRoot);
+		const configRoot = inferredRoot && inferredRoot !== '.' && inferredRoot !== '/'
+			? this.workspaceModuleService.normalizeRootPath(inferredRoot)
+			: this.workspaceModuleService.normalizeRootPath(defaultRoot);
 		const config = await this.workspaceModuleService.initializeConfig(workspaceRoot, configRoot);
 		await this.setWorkspaceInitializationContext(false);
 		return config;
@@ -2290,14 +2315,16 @@ export class ModuleManagerController {
 		const managedPaths = new Set(
 			Object.values(config?.modules ?? {}).map((entry) => entry.path.replace(/\\/g, '/').toLowerCase()),
 		);
-		const directories = await this.workspaceModuleService.listModuleDirectories(workspaceRoot, moduleRoot);
+		const directories = await this.listModuleDirectoriesForNamespaceScan(workspaceRoot, moduleRoot, this.getModuleDirectoryScanOptions());
 		const entries: LocalUnmanagedFolderEntry[] = directories
-			.map((directoryName) => {
-				const relativePath = path.posix.join(moduleRoot, directoryName);
+			.map((relativePathFromRoot) => {
+				const relativePath = path.posix.join(moduleRoot, relativePathFromRoot);
+				const normalizedRelativePathFromRoot = this.normalizeNamespacePathValue(relativePathFromRoot);
+				const folderName = path.posix.basename(normalizedRelativePathFromRoot || relativePathFromRoot);
 				const result: LocalUnmanagedFolderEntry = {
 					id: relativePath,
 					kind: 'unmanaged',
-					name: directoryName,
+					name: folderName,
 					path: relativePath,
 				};
 				return result;
@@ -2803,6 +2830,207 @@ export class ModuleManagerController {
 		}
 	}
 
+	private normalizeNamespacePathValue(value: string): string {
+		const service = this.workspaceModuleService as WorkspaceModuleService & { normalizeNamespacePath?: (value: string) => string };
+		if (typeof service.normalizeNamespacePath === 'function') {
+			return service.normalizeNamespacePath(value);
+		}
+		const trimmed = value.trim();
+		if (!trimmed) {
+			return '';
+		}
+		const slashNormalized = trimmed.replace(/\\/g, '/');
+		const normalized = slashNormalized.replace(/^\.\//, '').replace(/^\/+|\/+$/g, '');
+		return normalized === '.' ? '' : normalized;
+	}
+
+	private async listModuleDirectoriesForNamespaceScan(
+		workspaceRoot: string,
+		moduleRoot: string,
+		options: { maxDepth?: number; includeReadmeWeakSignal?: boolean } = {},
+	): Promise<string[]> {
+		const service = this.workspaceModuleService as WorkspaceModuleService & { listModuleDirectories?: (repoRoot: string, rootRelativePath: string, scanOptions?: { maxDepth?: number; includeReadmeWeakSignal?: boolean }) => Promise<string[]> };
+		if (typeof service.listModuleDirectories === 'function') {
+			return service.listModuleDirectories(workspaceRoot, moduleRoot, options);
+		}
+		return [];
+	}
+
+	private getModuleDirectoryScanOptions(): { maxDepth: number; includeReadmeWeakSignal: boolean } {
+		const configuration = vscode.workspace.getConfiguration(CONFIG_SECTIONS.moduleManager);
+		const configuredDepth = configuration.get<number>(CONFIG_KEYS.moduleScanMaxDepth, 3);
+		const maxDepth = Math.max(1, Math.floor(Number.isFinite(configuredDepth) ? configuredDepth : 3));
+		const includeReadmeWeakSignal = configuration.get<boolean>(CONFIG_KEYS.moduleScanIncludeReadmeWeakSignal, true);
+		return {
+			maxDepth,
+			includeReadmeWeakSignal,
+		};
+	}
+
+	private getWorkspaceRecentNamespaceKey(workspaceFolder: vscode.WorkspaceFolder): string {
+		return workspaceFolder.uri.fsPath.toLowerCase();
+	}
+
+	private getRecentNamespaceForWorkspace(workspaceFolder: vscode.WorkspaceFolder): string {
+		const key = this.getWorkspaceRecentNamespaceKey(workspaceFolder);
+		const stored = this.recentNamespaceByWorkspace[key];
+		if (!stored) {
+			return ROOT_NAMESPACE_VALUE;
+		}
+		try {
+			return this.normalizeNamespacePathValue(stored);
+		} catch {
+			return ROOT_NAMESPACE_VALUE;
+		}
+	}
+
+	private async setRecentNamespaceForWorkspace(workspaceFolder: vscode.WorkspaceFolder, namespacePath: string): Promise<void> {
+		const key = this.getWorkspaceRecentNamespaceKey(workspaceFolder);
+		this.recentNamespaceByWorkspace = {
+			...this.recentNamespaceByWorkspace,
+			[key]: namespacePath,
+		};
+		await this.cacheStore.setRecentNamespaceByWorkspace(this.recentNamespaceByWorkspace);
+	}
+
+	private collectNamespaceCandidates(config: LocalModuleConfig): string[] {
+		const namespaceSet = new Set<string>();
+		namespaceSet.add(ROOT_NAMESPACE_VALUE);
+
+		const collectFromPath = (fullPath: string): void => {
+			let normalized: string;
+			try {
+				normalized = this.workspaceModuleService.normalizeRootPath(fullPath);
+			} catch {
+				return;
+			}
+			if (!(normalized === config.root || normalized.startsWith(`${config.root}/`))) {
+				return;
+			}
+			const relativeToRoot = normalized === config.root ? '' : normalized.slice(config.root.length + 1);
+			if (!relativeToRoot) {
+				return;
+			}
+			const segments = relativeToRoot.split('/').filter((segment) => segment.length > 0);
+			for (let depth = 1; depth < segments.length; depth += 1) {
+				namespaceSet.add(segments.slice(0, depth).join('/'));
+			}
+		};
+
+		for (const managed of Object.values(config.modules)) {
+			collectFromPath(managed.path);
+		}
+
+		return [...namespaceSet].sort((left, right) => left.localeCompare(right));
+	}
+
+	private async promptApplyTargetNamespace(
+		workspaceFolder: vscode.WorkspaceFolder,
+		workspaceRoot: string,
+		config: LocalModuleConfig,
+	): Promise<string | undefined> {
+		const managedAndUnmanagedNamespace = new Set(this.collectNamespaceCandidates(config));
+		const managedPaths = new Set(
+			Object.values(config.modules).map((entry) => entry.path.replace(/\\/g, '/').toLowerCase()),
+		);
+		const scanCandidates = await this.listModuleDirectoriesForNamespaceScan(
+			workspaceRoot,
+			config.root,
+			this.getModuleDirectoryScanOptions(),
+		);
+		for (const relativePathFromRoot of scanCandidates) {
+			const fullPath = path.posix.join(config.root, relativePathFromRoot);
+			if (managedPaths.has(fullPath.toLowerCase())) {
+				continue;
+			}
+			const relativeToRoot = relativePathFromRoot;
+			if (!relativeToRoot) {
+				continue;
+			}
+			const segments = relativeToRoot.split('/').filter((segment) => segment.length > 0);
+			for (let depth = 1; depth < segments.length; depth += 1) {
+				managedAndUnmanagedNamespace.add(segments.slice(0, depth).join('/'));
+			}
+		}
+
+		const sortedNamespaces = [...managedAndUnmanagedNamespace].sort((left, right) => left.localeCompare(right));
+		const recentNamespace = this.getRecentNamespaceForWorkspace(workspaceFolder);
+		const nonRootNamespaces = sortedNamespaces.filter((namespacePath) => namespacePath.length > 0);
+		if (nonRootNamespaces.length === 0 && recentNamespace === ROOT_NAMESPACE_VALUE) {
+			return ROOT_NAMESPACE_VALUE;
+		}
+		const rootOptionLabel = t('applyNamespaceRootOption', { root: config.root });
+		const items: NamespaceQuickPickItem[] = [
+			{
+				label: rootOptionLabel,
+				detail: t('applyNamespaceRootDetail', { root: config.root }),
+				namespacePath: ROOT_NAMESPACE_VALUE,
+				picked: recentNamespace === ROOT_NAMESPACE_VALUE,
+			},
+			...sortedNamespaces
+				.filter((namespacePath) => namespacePath.length > 0)
+				.map((namespacePath) => ({
+					label: namespacePath,
+					detail: t('applyNamespacePathDetail', { path: path.posix.join(config.root, namespacePath) }),
+					namespacePath,
+					picked: recentNamespace === namespacePath,
+				})),
+			{
+				label: t('applyNamespaceManualInput'),
+				detail: t('applyNamespaceManualInputDetail'),
+				action: 'manual',
+			},
+		];
+
+		const picked = await vscode.window.showQuickPick(items, {
+			placeHolder: t('applyNamespacePlaceholder'),
+			matchOnDetail: true,
+		});
+		if (!picked) {
+			return undefined;
+		}
+
+		let chosenNamespace = picked.namespacePath ?? ROOT_NAMESPACE_VALUE;
+		if (picked.action === 'manual') {
+			const input = await vscode.window.showInputBox({
+				prompt: t('applyNamespaceInputPrompt', { root: config.root }),
+				placeHolder: 'HAL/niDMM',
+				validateInput: (value) => {
+					try {
+						this.normalizeNamespacePathValue(value);
+						return undefined;
+					} catch (error) {
+						return error instanceof Error ? error.message : t('invalidDirectory');
+					}
+				},
+			});
+			if (typeof input === 'undefined') {
+				return undefined;
+			}
+			chosenNamespace = this.normalizeNamespacePathValue(input);
+
+			const targetDirectory = chosenNamespace
+				? path.posix.join(config.root, chosenNamespace)
+				: config.root;
+			const exists = await this.workspaceModuleService.targetExists(workspaceRoot, targetDirectory);
+			if (!exists) {
+				const confirmation = await vscode.window.showWarningMessage(
+					t('applyNamespaceCreateConfirm', { path: targetDirectory }),
+					{ modal: true },
+					t('applyNamespaceCreateAction'),
+				);
+				if (confirmation !== t('applyNamespaceCreateAction')) {
+					return undefined;
+				}
+				await fs.mkdir(path.join(workspaceRoot, ...targetDirectory.split('/')), { recursive: true });
+				void vscode.window.showInformationMessage(t('applyNamespaceTip', { path: targetDirectory }));
+			}
+		}
+
+		await this.setRecentNamespaceForWorkspace(workspaceFolder, chosenNamespace);
+		return chosenNamespace;
+	}
+
 	private async hasLvprojFile(workspaceFolder: vscode.WorkspaceFolder): Promise<boolean> {
 		const matches = await vscode.workspace.findFiles(
 			new vscode.RelativePattern(workspaceFolder, LVPROJ_GLOB),
@@ -2861,11 +3089,16 @@ export class ModuleManagerController {
 		return pick?.method;
 	}
 
-	private findDuplicateTargetPaths(config: LocalModuleConfig, entries: CsmModuleEntry[]): string[] {
+	private findDuplicateTargetPaths(
+		config: LocalModuleConfig,
+		entries: CsmModuleEntry[],
+		explicitTargetPathsByModuleKey?: Map<string, string>,
+	): string[] {
 		const seen = new Set<string>();
 		const duplicates = new Set<string>();
 		for (const entry of entries) {
-			const targetPath = this.workspaceModuleService.getTargetRelativePath(config, entry);
+			const targetPath = explicitTargetPathsByModuleKey?.get(this.getModuleKey(entry))
+				?? this.workspaceModuleService.getTargetRelativePath(config, entry);
 			if (seen.has(targetPath)) {
 				duplicates.add(targetPath);
 				continue;
@@ -2879,10 +3112,12 @@ export class ModuleManagerController {
 		repoRoot: string,
 		config: LocalModuleConfig,
 		entries: CsmModuleEntry[],
+		explicitTargetPathsByModuleKey?: Map<string, string>,
 	): Promise<string[]> {
 		const occupied: string[] = [];
 		for (const entry of entries) {
-			const targetPath = this.workspaceModuleService.getTargetRelativePath(config, entry);
+			const targetPath = explicitTargetPathsByModuleKey?.get(this.getModuleKey(entry))
+				?? this.workspaceModuleService.getTargetRelativePath(config, entry);
 			if (await this.workspaceModuleService.targetExists(repoRoot, targetPath)) {
 				occupied.push(targetPath);
 			}

--- a/src/modules/moduleManagerController.ts
+++ b/src/modules/moduleManagerController.ts
@@ -9,7 +9,7 @@ import { ModuleTreeItem } from './moduleTreeTypes';
 import { ModuleSidebarViewProvider } from './moduleSidebarViewProvider';
 import { IModuleViewProvider, ModuleSortField, ModuleSortState, SidebarWorkspaceContext } from './types';
 import { ReadmeAssetCache } from './readmeAssetCache';
-import { DEFAULT_LOCAL_MODULE_ROOT, GitIdentity, LEGACY_LOCAL_MODULE_CONFIG_FILE, LOCAL_MODULE_CONFIG_FILE, WorkspaceModuleService } from './workspaceModuleService';
+import { DEFAULT_EXCLUDED_DIRECTORY_NAMES, DEFAULT_LOCAL_MODULE_ROOT, GitIdentity, LEGACY_LOCAL_MODULE_CONFIG_FILE, LOCAL_MODULE_CONFIG_FILE, WorkspaceModuleService } from './workspaceModuleService';
 import { COMMAND_IDS, CONFIG_KEYS, CONFIG_SECTIONS, CONTEXT_KEYS, GITHUB, VIEW_IDS } from './constants';
 import { Logger, getLogger, wrapCommand } from './logger';
 import { getApplyMethodLabel, t } from './messages';
@@ -2312,10 +2312,14 @@ export class ModuleManagerController {
 		moduleRoot: string,
 		config: LocalModuleConfig | undefined,
 	): Promise<LocalUnmanagedFolderEntry[]> {
+		const managedEntries = Object.values(config?.modules ?? {});
 		const managedPaths = new Set(
-			Object.values(config?.modules ?? {}).map((entry) => entry.path.replace(/\\/g, '/').toLowerCase()),
+			managedEntries.map((entry) => entry.path.replace(/\\/g, '/').toLowerCase()),
 		);
-		const directories = await this.listModuleDirectoriesForNamespaceScan(workspaceRoot, moduleRoot, this.getModuleDirectoryScanOptions());
+		const directories = await this.listModuleDirectoriesForNamespaceScan(workspaceRoot, moduleRoot, {
+			...this.getModuleDirectoryScanOptions(),
+			excludedRelativePaths: this.toManagedRelativePaths(managedEntries, moduleRoot),
+		});
 		const entries: LocalUnmanagedFolderEntry[] = directories
 			.map((relativePathFromRoot) => {
 				const relativePath = path.posix.join(moduleRoot, relativePathFromRoot);
@@ -2847,24 +2851,45 @@ export class ModuleManagerController {
 	private async listModuleDirectoriesForNamespaceScan(
 		workspaceRoot: string,
 		moduleRoot: string,
-		options: { maxDepth?: number; includeReadmeWeakSignal?: boolean } = {},
+		options: { maxDepth?: number; includeReadmeWeakSignal?: boolean; excludedDirectoryNames?: string[]; excludedRelativePaths?: string[] } = {},
 	): Promise<string[]> {
-		const service = this.workspaceModuleService as WorkspaceModuleService & { listModuleDirectories?: (repoRoot: string, rootRelativePath: string, scanOptions?: { maxDepth?: number; includeReadmeWeakSignal?: boolean }) => Promise<string[]> };
+		const service = this.workspaceModuleService as WorkspaceModuleService & { listModuleDirectories?: (repoRoot: string, rootRelativePath: string, scanOptions?: { maxDepth?: number; includeReadmeWeakSignal?: boolean; excludedDirectoryNames?: string[]; excludedRelativePaths?: string[] }) => Promise<string[]> };
 		if (typeof service.listModuleDirectories === 'function') {
 			return service.listModuleDirectories(workspaceRoot, moduleRoot, options);
 		}
 		return [];
 	}
 
-	private getModuleDirectoryScanOptions(): { maxDepth: number; includeReadmeWeakSignal: boolean } {
+	private getModuleDirectoryScanOptions(): { maxDepth: number; includeReadmeWeakSignal: boolean; excludedDirectoryNames: string[] } {
 		const configuration = vscode.workspace.getConfiguration(CONFIG_SECTIONS.moduleManager);
 		const configuredDepth = configuration.get<number>(CONFIG_KEYS.moduleScanMaxDepth, 3);
 		const maxDepth = Math.max(1, Math.floor(Number.isFinite(configuredDepth) ? configuredDepth : 3));
 		const includeReadmeWeakSignal = configuration.get<boolean>(CONFIG_KEYS.moduleScanIncludeReadmeWeakSignal, true);
+		const configuredExcluded = configuration.get<string[]>(CONFIG_KEYS.moduleScanExcludedDirectories, DEFAULT_EXCLUDED_DIRECTORY_NAMES);
+		const excludedDirectoryNames = Array.isArray(configuredExcluded)
+			? configuredExcluded.map((name) => String(name).trim()).filter((name) => name.length > 0)
+			: [];
 		return {
 			maxDepth,
 			includeReadmeWeakSignal,
+			excludedDirectoryNames,
 		};
+	}
+
+	private toManagedRelativePaths(entries: Array<{ path: string }>, moduleRoot: string): string[] {
+		const rootPrefix = `${moduleRoot}/`;
+		const relativePaths: string[] = [];
+		for (const entry of entries) {
+			const normalized = entry.path.replace(/\\/g, '/').replace(/^\/+|\/+$/g, '');
+			if (normalized === moduleRoot) {
+				continue;
+			}
+			if (!normalized.startsWith(rootPrefix)) {
+				continue;
+			}
+			relativePaths.push(normalized.slice(rootPrefix.length));
+		}
+		return relativePaths;
 	}
 
 	private getWorkspaceRecentNamespaceKey(workspaceFolder: vscode.WorkspaceFolder): string {
@@ -2930,13 +2955,17 @@ export class ModuleManagerController {
 		config: LocalModuleConfig,
 	): Promise<string | undefined> {
 		const managedAndUnmanagedNamespace = new Set(this.collectNamespaceCandidates(config));
+		const managedEntries = Object.values(config.modules);
 		const managedPaths = new Set(
-			Object.values(config.modules).map((entry) => entry.path.replace(/\\/g, '/').toLowerCase()),
+			managedEntries.map((entry) => entry.path.replace(/\\/g, '/').toLowerCase()),
 		);
 		const scanCandidates = await this.listModuleDirectoriesForNamespaceScan(
 			workspaceRoot,
 			config.root,
-			this.getModuleDirectoryScanOptions(),
+			{
+				...this.getModuleDirectoryScanOptions(),
+				excludedRelativePaths: this.toManagedRelativePaths(managedEntries, config.root),
+			},
 		);
 		for (const relativePathFromRoot of scanCandidates) {
 			const fullPath = path.posix.join(config.root, relativePathFromRoot);

--- a/src/modules/workspaceModuleService.ts
+++ b/src/modules/workspaceModuleService.ts
@@ -57,6 +57,11 @@ export interface ModuleDirectoryScanOptions {
 	maxDepth?: number;
 	includeReadmeWeakSignal?: boolean;
 	excludedDirectoryNames?: string[];
+	/**
+	 * 相对模块根目录的路径，扫描时整体跳过（不报告为候选、不深入其子目录）。
+	 * 用于已管理模块目录，避免继续向下扫描其内部内容。
+	 */
+	excludedRelativePaths?: string[];
 }
 
 function toPosixPath(value: string): string {
@@ -71,8 +76,8 @@ function stripGitSuffix(value: string): string {
 	return value.replace(/\.git$/i, '');
 }
 
-const DEFAULT_SCAN_MAX_DEPTH = 3;
-const DEFAULT_EXCLUDED_DIRECTORY_NAMES = ['.git', 'node_modules', 'dist', 'build', 'out', 'tmp', 'docs', 'images'];
+export const DEFAULT_SCAN_MAX_DEPTH = 3;
+export const DEFAULT_EXCLUDED_DIRECTORY_NAMES = ['.git', 'node_modules', 'dist', 'build', 'out', 'tmp', 'docs', 'images'];
 const DOCUMENT_OR_IMAGE_FILE_PATTERN = /^(readme(\..*)?|license(\..*)?|changelog(\..*)?|notice(\..*)?|copying(\..*)?|authors(\..*)?|contributing(\..*)?|.*\.(md|txt|rst|png|jpe?g|gif|bmp|webp|svg))$/i;
 
 export class WorkspaceModuleService {
@@ -526,6 +531,11 @@ export class WorkspaceModuleService {
 				.map((name) => name.trim().toLowerCase())
 				.filter((name) => name.length > 0),
 		);
+		const excludedRelativePaths = new Set(
+			(options.excludedRelativePaths ?? [])
+				.map((value) => value.replace(/\\/g, '/').replace(/^\/+|\/+$/g, '').toLowerCase())
+				.filter((value) => value.length > 0),
+		);
 		let entries: Dirent[];
 		try {
 			entries = await fs.readdir(rootAbsolute, { withFileTypes: true });
@@ -538,6 +548,10 @@ export class WorkspaceModuleService {
 
 		const discovered = new Set<string>();
 		const walk = async (relativePathFromRoot: string, depth: number): Promise<void> => {
+			const relativePathKey = relativePathFromRoot.replace(/\\/g, '/').toLowerCase();
+			if (relativePathKey && excludedRelativePaths.has(relativePathKey)) {
+				return;
+			}
 			const absolutePath = this.toAbsoluteTargetPath(repoRoot, path.posix.join(root, relativePathFromRoot));
 			let children: Dirent[];
 			try {
@@ -577,6 +591,9 @@ export class WorkspaceModuleService {
 				return false;
 			}
 			if (entry.name.startsWith('.')) {
+				return false;
+			}
+			if (excludedRelativePaths.has(entry.name.toLowerCase())) {
 				return false;
 			}
 			return !excludedDirectoryNames.has(entry.name.toLowerCase());

--- a/src/modules/workspaceModuleService.ts
+++ b/src/modules/workspaceModuleService.ts
@@ -53,6 +53,12 @@ export interface PublishLocalFolderResult {
 	createdCommit: boolean;
 }
 
+export interface ModuleDirectoryScanOptions {
+	maxDepth?: number;
+	includeReadmeWeakSignal?: boolean;
+	excludedDirectoryNames?: string[];
+}
+
 function toPosixPath(value: string): string {
 	return value.replace(/\\/g, '/');
 }
@@ -65,6 +71,10 @@ function stripGitSuffix(value: string): string {
 	return value.replace(/\.git$/i, '');
 }
 
+const DEFAULT_SCAN_MAX_DEPTH = 3;
+const DEFAULT_EXCLUDED_DIRECTORY_NAMES = ['.git', 'node_modules', 'dist', 'build', 'out', 'tmp', 'docs', 'images'];
+const DOCUMENT_OR_IMAGE_FILE_PATTERN = /^(readme(\..*)?|license(\..*)?|changelog(\..*)?|notice(\..*)?|copying(\..*)?|authors(\..*)?|contributing(\..*)?|.*\.(md|txt|rst|png|jpe?g|gif|bmp|webp|svg))$/i;
+
 export class WorkspaceModuleService {
 	constructor(private readonly gitRunner: IGitRunner = new GitService()) { }
 
@@ -76,8 +86,35 @@ export class WorkspaceModuleService {
 		return `${sanitizeModuleKeyPart(entry.owner)}__${sanitizeModuleKeyPart(entry.name)}`;
 	}
 
-	public getTargetRelativePath(config: LocalModuleConfig, entry: CsmModuleEntry): string {
-		return path.posix.join(config.root, entry.name);
+	public normalizeNamespacePath(value: string): string {
+		const trimmed = value.trim();
+		if (!trimmed) {
+			return '';
+		}
+
+		const slashNormalized = trimmed.replace(/\\/g, '/');
+		if (path.posix.isAbsolute(slashNormalized) || path.win32.isAbsolute(trimmed)) {
+			throw new Error('Use a namespace path relative to the module root.');
+		}
+
+		const normalized = path.posix.normalize(slashNormalized).replace(/^\.\//, '').replace(/^\/+|\/+$/g, '');
+		if (normalized === '.') {
+			return '';
+		}
+		if (!normalized || normalized.startsWith('..') || normalized.includes('/../')) {
+			throw new Error('The namespace path must stay inside the module root.');
+		}
+
+		return normalized;
+	}
+
+	public getTargetRelativePath(config: LocalModuleConfig, entry: CsmModuleEntry, namespaceRelativePath?: string): string {
+		const namespace = typeof namespaceRelativePath === 'string'
+			? this.normalizeNamespacePath(namespaceRelativePath)
+			: '';
+		return namespace
+			? path.posix.join(config.root, namespace, entry.name)
+			: path.posix.join(config.root, entry.name);
 	}
 
 	public async resolveGitRepositoryRoot(workspacePath: string): Promise<string | undefined> {
@@ -475,9 +512,20 @@ export class WorkspaceModuleService {
 		}
 	}
 
-	public async listModuleDirectories(repoRoot: string, rootRelativePath: string): Promise<string[]> {
+	public async listModuleDirectories(
+		repoRoot: string,
+		rootRelativePath: string,
+		options: ModuleDirectoryScanOptions = {},
+	): Promise<string[]> {
 		const root = this.normalizeRootPath(rootRelativePath);
 		const rootAbsolute = this.toAbsoluteTargetPath(repoRoot, root);
+		const maxDepth = Math.max(1, Math.floor(options.maxDepth ?? DEFAULT_SCAN_MAX_DEPTH));
+		const includeReadmeWeakSignal = options.includeReadmeWeakSignal !== false;
+		const excludedDirectoryNames = new Set(
+			(options.excludedDirectoryNames ?? DEFAULT_EXCLUDED_DIRECTORY_NAMES)
+				.map((name) => name.trim().toLowerCase())
+				.filter((name) => name.length > 0),
+		);
 		let entries: Dirent[];
 		try {
 			entries = await fs.readdir(rootAbsolute, { withFileTypes: true });
@@ -487,10 +535,58 @@ export class WorkspaceModuleService {
 			}
 			throw error;
 		}
-		return entries
-			.filter((entry) => entry.isDirectory() && !entry.name.startsWith('.'))
-			.map((entry) => entry.name)
-			.sort((left, right) => left.localeCompare(right));
+
+		const discovered = new Set<string>();
+		const walk = async (relativePathFromRoot: string, depth: number): Promise<void> => {
+			const absolutePath = this.toAbsoluteTargetPath(repoRoot, path.posix.join(root, relativePathFromRoot));
+			let children: Dirent[];
+			try {
+				children = await fs.readdir(absolutePath, { withFileTypes: true });
+			} catch (error) {
+				if (this.isMissingPathError(error)) {
+					return;
+				}
+				throw error;
+			}
+
+			if (this.isModuleCandidateDirectory(children, includeReadmeWeakSignal)) {
+				discovered.add(relativePathFromRoot);
+			}
+
+			if (depth >= maxDepth) {
+				return;
+			}
+
+			const nextDirectories = children.filter((entry) => {
+				if (!entry.isDirectory()) {
+					return false;
+				}
+				if (entry.name.startsWith('.')) {
+					return false;
+				}
+				return !excludedDirectoryNames.has(entry.name.toLowerCase());
+			});
+
+			for (const child of nextDirectories) {
+				await walk(path.posix.join(relativePathFromRoot, child.name), depth + 1);
+			}
+		};
+
+		const topDirectories = entries.filter((entry) => {
+			if (!entry.isDirectory()) {
+				return false;
+			}
+			if (entry.name.startsWith('.')) {
+				return false;
+			}
+			return !excludedDirectoryNames.has(entry.name.toLowerCase());
+		});
+
+		for (const entry of topDirectories) {
+			await walk(entry.name, 1);
+		}
+
+		return [...discovered].sort((left, right) => left.localeCompare(right));
 	}
 
 	public async applyModule(
@@ -500,8 +596,11 @@ export class WorkspaceModuleService {
 		method: ModuleApplyMethod,
 		authToken?: string,
 		onProgress?: (message: string) => void,
+		explicitTargetRelativePath?: string,
 	): Promise<LocalModuleConfigEntry> {
-		const targetRelativePath = this.getTargetRelativePath(config, entry);
+		const targetRelativePath = explicitTargetRelativePath
+			? this.normalizeRootPath(explicitTargetRelativePath)
+			: this.getTargetRelativePath(config, entry);
 		const targetPath = this.toAbsoluteTargetPath(repoRoot, targetRelativePath);
 		if (await this.targetExists(repoRoot, targetRelativePath)) {
 			if (method === 'copy') {
@@ -692,6 +791,38 @@ export class WorkspaceModuleService {
 		} finally {
 			await fs.rm(tempRoot, { recursive: true, force: true });
 		}
+	}
+
+	private isModuleCandidateDirectory(entries: Dirent[], includeReadmeWeakSignal: boolean): boolean {
+		const hasStrongSignal = entries.some((entry) => {
+			if (entry.name === '.git') {
+				return true;
+			}
+			if (!entry.isFile()) {
+				return false;
+			}
+			return /^DEV ENVIRONMENT/i.test(entry.name) || /\.(lvproj|lvlib)$/i.test(entry.name);
+		});
+		if (hasStrongSignal) {
+			return true;
+		}
+
+		if (!includeReadmeWeakSignal) {
+			return false;
+		}
+
+		const hasReadme = entries.some((entry) => entry.isFile() && /^readme(\..*)?$/i.test(entry.name));
+		if (!hasReadme) {
+			return false;
+		}
+
+		const hasNonDocumentationFile = entries.some((entry) => {
+			if (!entry.isFile()) {
+				return false;
+			}
+			return !DOCUMENT_OR_IMAGE_FILE_PATTERN.test(entry.name);
+		});
+		return hasNonDocumentationFile;
 	}
 
 	private async convertSubmoduleToCopy(

--- a/src/test/moduleManagerBoundary.test.ts
+++ b/src/test/moduleManagerBoundary.test.ts
@@ -103,4 +103,58 @@ suite('Module Manager Boundary Tests', () => {
 			await fs.rm(tmpDir, { recursive: true, force: true });
 		}
 	});
+
+	test('listModuleDirectories skips excluded relative paths (managed module subtrees)', async () => {
+		const service = new WorkspaceModuleService();
+		const tmpDir = await fs.mkdtemp(path.join(getTempRoot(), 'csm-scan-'));
+		try {
+			// csm/
+			//   managed-a/          → excluded entirely (managed module)
+			//     inner/
+			//       data.lvlib      → strong signal; must NOT appear
+			//   other/
+			//     README.md
+			//     main.vi           → weak signal; must appear
+			const root = path.join(tmpDir, 'csm');
+			await fs.mkdir(path.join(root, 'managed-a', 'inner'), { recursive: true });
+			await fs.writeFile(path.join(root, 'managed-a', 'inner', 'data.lvlib'), '', 'utf8');
+			await fs.mkdir(path.join(root, 'other'), { recursive: true });
+			await fs.writeFile(path.join(root, 'other', 'README.md'), '# Other', 'utf8');
+			await fs.writeFile(path.join(root, 'other', 'main.vi'), '', 'utf8');
+
+			const discovered = await service.listModuleDirectories(tmpDir, 'csm', {
+				maxDepth: 3,
+				includeReadmeWeakSignal: true,
+				excludedRelativePaths: ['managed-a'],
+			});
+			assert.deepStrictEqual(discovered, ['other']);
+		} finally {
+			await fs.rm(tmpDir, { recursive: true, force: true });
+		}
+	});
+
+	test('listModuleDirectories skips default excluded directory names', async () => {
+		const service = new WorkspaceModuleService();
+		const tmpDir = await fs.mkdtemp(path.join(getTempRoot(), 'csm-skip-'));
+		try {
+			// csm/
+			//   node_modules/       → default excluded name
+			//     index.js + README → would otherwise be a weak-signal candidate
+			//   real/
+			//     README.md
+			//     main.vi           → weak signal; must appear
+			const root = path.join(tmpDir, 'csm');
+			await fs.mkdir(path.join(root, 'node_modules'), { recursive: true });
+			await fs.writeFile(path.join(root, 'node_modules', 'index.js'), '', 'utf8');
+			await fs.writeFile(path.join(root, 'node_modules', 'README.md'), 'x', 'utf8');
+			await fs.mkdir(path.join(root, 'real'), { recursive: true });
+			await fs.writeFile(path.join(root, 'real', 'README.md'), '# real', 'utf8');
+			await fs.writeFile(path.join(root, 'real', 'main.vi'), '', 'utf8');
+
+			const discovered = await service.listModuleDirectories(tmpDir, 'csm');
+			assert.deepStrictEqual(discovered, ['real']);
+		} finally {
+			await fs.rm(tmpDir, { recursive: true, force: true });
+		}
+	});
 });

--- a/src/test/moduleManagerController.test.ts
+++ b/src/test/moduleManagerController.test.ts
@@ -2120,6 +2120,71 @@ suite('ModuleManagerController Regression Tests', () => {
 		assert.ok(infos.some((text) => text.includes('Applied 1 module(s) via copy')));
 	});
 
+	test('apply uses the selected namespace when computing the module target path', async () => {
+		const controller = createController() as any;
+		const entry: CsmModuleEntry = {
+			id: 2,
+			owner: 'org',
+			name: 'module-b',
+			description: 'demo',
+			topics: ['csm-modsets'],
+			visibility: 'public',
+			defaultBranch: 'main',
+			repoUrl: 'https://github.com/org/module-b',
+		};
+		const config: LocalModuleConfig = {
+			version: '2',
+			root: 'csm',
+			configPath: 'd:/repo/csm/csm-modules.yaml',
+			modules: {},
+		};
+		let appliedTargetPath: string | undefined;
+
+		controller.workspaceModuleService = {
+			resolveGitRepositoryRoot: async () => 'd:/repo',
+			normalizeRootPath: (value: string) => value.replace(/\\/g, '/').replace(/^\.\//, '').replace(/^\/+|\/+$/g, ''),
+			normalizeNamespacePath: (value: string) => value.trim().replace(/\\/g, '/').replace(/^\/+|\/+$/g, '').replace(/^\.\//, ''),
+			recoverConfigFromExistingSubmodules: async () => undefined,
+			loadConfig: async () => config,
+			listModuleDirectories: async () => ['shared/feature'],
+			getTargetRelativePath: (_config: LocalModuleConfig, _moduleEntry: CsmModuleEntry, namespaceRelativePath?: string) => {
+				const namespace = namespaceRelativePath ? `/${namespaceRelativePath}` : '';
+				return `csm${namespace}/module-b`;
+			},
+			targetExists: async () => false,
+			applyModule: async (_repoRoot: string, _config: LocalModuleConfig, _moduleEntry: CsmModuleEntry, _method: ModuleApplyMethod, _authToken?: string, _onProgress?: (message: string) => void, explicitTargetRelativePath?: string) => {
+				appliedTargetPath = explicitTargetRelativePath;
+				return {
+					key: 'org__module_b',
+					name: 'module-b',
+					owner: 'org',
+					source: entry.repoUrl,
+					method: 'copy',
+					path: explicitTargetRelativePath ?? 'csm/module-b',
+					ref: 'abc123',
+					branch: entry.defaultBranch,
+				};
+			},
+			withAppliedModule: (currentConfig: LocalModuleConfig, moduleEntry: LocalModuleConfig['modules'][string]) => ({
+				...currentConfig,
+				modules: {
+					...currentConfig.modules,
+					[moduleEntry.key]: moduleEntry,
+				},
+			}),
+			writeConfig: async () => undefined,
+		};
+		mocked.__setWorkspaceFolders([{ name: 'repo', uri: vscode.Uri.file('d:/repo') }]);
+		mocked.__setFindFilesResult([vscode.Uri.file('d:/repo/csm/csm-modules.yaml')]);
+		mocked.__setQuickPickResponse({ method: 'copy' });
+		mocked.__setQuickPickResponse({ namespacePath: 'shared/feature' });
+		mocked.__setWarningMessageResponse('Apply');
+
+		await controller.applyToWorkspaceCommand(entry);
+
+		assert.strictEqual(appliedTargetPath, 'csm/shared/feature/module-b');
+	});
+
 	test('apply keeps existing config root when default root setting differs', async () => {
 		const controller = createController() as any;
 		const entry: CsmModuleEntry = {

--- a/src/test/moduleManagerController.test.ts
+++ b/src/test/moduleManagerController.test.ts
@@ -2185,6 +2185,133 @@ suite('ModuleManagerController Regression Tests', () => {
 		assert.strictEqual(appliedTargetPath, 'csm/shared/feature/module-b');
 	});
 
+	test('apply namespace scan excludes already-managed module directories', async () => {
+		const controller = createController() as any;
+		const entry: CsmModuleEntry = {
+			id: 2,
+			owner: 'org',
+			name: 'module-b',
+			description: 'demo',
+			topics: ['csm-modsets'],
+			visibility: 'public',
+			defaultBranch: 'main',
+			repoUrl: 'https://github.com/org/module-b',
+		};
+		const config: LocalModuleConfig = {
+			version: '2',
+			root: 'csm',
+			configPath: 'd:/repo/csm/csm-modules.yaml',
+			modules: {
+				org__module_a: {
+					key: 'org__module_a',
+					name: 'module-a',
+					owner: 'org',
+					source: 'https://github.com/org/module-a',
+					method: 'copy',
+					path: 'csm/ns/module-a',
+					ref: 'abc123',
+					branch: 'main',
+				},
+			},
+		};
+		let capturedOptions: { excludedRelativePaths?: string[] } | undefined;
+		controller.workspaceModuleService = {
+			resolveGitRepositoryRoot: async () => 'd:/repo',
+			normalizeRootPath: (value: string) => value,
+			normalizeNamespacePath: (value: string) => value.trim().replace(/\\/g, '/').replace(/^\/+|\/+$/g, '').replace(/^\.\//, ''),
+			recoverConfigFromExistingSubmodules: async () => undefined,
+			loadConfig: async () => config,
+			listModuleDirectories: async (_repoRoot: string, _root: string, options?: { excludedRelativePaths?: string[] }) => {
+				capturedOptions = options;
+				return ['shared/feature'];
+			},
+			getTargetRelativePath: (_config: LocalModuleConfig, _moduleEntry: CsmModuleEntry, namespaceRelativePath?: string) => {
+				const namespace = namespaceRelativePath ? `/${namespaceRelativePath}` : '';
+				return `csm${namespace}/module-b`;
+			},
+			targetExists: async () => false,
+			applyModule: async (_repoRoot: string, _config: LocalModuleConfig, _moduleEntry: CsmModuleEntry, _method: ModuleApplyMethod, _authToken?: string, _onProgress?: (message: string) => void, explicitTargetRelativePath?: string) => ({
+				key: 'org__module_b',
+				name: 'module-b',
+				owner: 'org',
+				source: entry.repoUrl,
+				method: 'copy',
+				path: explicitTargetRelativePath ?? 'csm/module-b',
+				ref: 'abc123',
+				branch: entry.defaultBranch,
+			}),
+			withAppliedModule: (currentConfig: LocalModuleConfig, moduleEntry: LocalModuleConfig['modules'][string]) => ({
+				...currentConfig,
+				modules: {
+					...currentConfig.modules,
+					[moduleEntry.key]: moduleEntry,
+				},
+			}),
+			writeConfig: async () => undefined,
+		};
+		mocked.__setWorkspaceFolders([{ name: 'repo', uri: vscode.Uri.file('d:/repo') }]);
+		mocked.__setFindFilesResult([vscode.Uri.file('d:/repo/csm/csm-modules.yaml')]);
+		mocked.__setQuickPickResponse({ method: 'copy' });
+		mocked.__setQuickPickResponse({ namespacePath: 'shared/feature' });
+		mocked.__setWarningMessageResponse('Apply');
+
+		await controller.applyToWorkspaceCommand(entry);
+
+		assert.deepStrictEqual(capturedOptions?.excludedRelativePaths, ['ns/module-a']);
+	});
+
+	test('mapUnmanagedFolders excludes managed module directories from scanning', async () => {
+		const controller = createController() as any;
+		let capturedOptions: { excludedRelativePaths?: string[]; excludedDirectoryNames?: string[] } | undefined;
+		controller.workspaceModuleService = {
+			listModuleDirectories: async (_repoRoot: string, _root: string, options?: { excludedRelativePaths?: string[]; excludedDirectoryNames?: string[] }) => {
+				capturedOptions = options;
+				return ['ns/other'];
+			},
+		};
+		const config: LocalModuleConfig = {
+			version: '2',
+			root: 'csm',
+			configPath: 'd:/repo/csm/csm-modules.yaml',
+			modules: {
+				org__module_a: {
+					key: 'org__module_a',
+					name: 'module-a',
+					owner: 'org',
+					source: 'https://github.com/org/module-a',
+					method: 'copy',
+					path: 'csm/ns/module-a',
+					ref: 'abc123',
+					branch: 'main',
+					locked: false,
+				},
+			},
+		};
+		const result = await controller.mapUnmanagedFolders('d:/repo', 'csm', config);
+		assert.deepStrictEqual(capturedOptions?.excludedRelativePaths, ['ns/module-a']);
+		assert.ok(capturedOptions?.excludedDirectoryNames?.includes('node_modules'));
+		assert.deepStrictEqual(result.map((entry: { path: string }) => entry.path), ['csm/ns/other']);
+	});
+
+	test('mapUnmanagedFolders respects configured excluded directories', async () => {
+		const controller = createController() as any;
+		let capturedOptions: { excludedDirectoryNames?: string[] } | undefined;
+		controller.workspaceModuleService = {
+			listModuleDirectories: async (_repoRoot: string, _root: string, options?: { excludedDirectoryNames?: string[] }) => {
+				capturedOptions = options;
+				return [];
+			},
+		};
+		mocked.__setConfigurationValue('csmModules.moduleScanExcludedDirectories', ['vendor', 'third_party']);
+		await controller.mapUnmanagedFolders('d:/repo', 'csm', {
+			version: '2',
+			root: 'csm',
+			configPath: 'd:/repo/csm/csm-modules.yaml',
+			modules: {},
+		});
+		assert.deepStrictEqual(capturedOptions?.excludedDirectoryNames, ['vendor', 'third_party']);
+	});
+
 	test('apply keeps existing config root when default root setting differs', async () => {
 		const controller = createController() as any;
 		const entry: CsmModuleEntry = {

--- a/src/test/vscode-mock.ts
+++ b/src/test/vscode-mock.ts
@@ -347,7 +347,7 @@ type MessageLevel = 'info' | 'warn' | 'error';
 const messageLog: Array<{ level: MessageLevel; text: string }> = [];
 let warningResponse: string | undefined;
 let informationResponse: unknown;
-let quickPickResponse: unknown;
+let quickPickResponses: unknown[] = [];
 let inputBoxResponse: string | undefined;
 let inputBoxResponses: Array<string | undefined> = [];
 let findFilesResult: Uri[] = [];
@@ -438,7 +438,8 @@ export const window = {
     async showQuickPick<T>(_items: readonly T[] | Promise<readonly T[]>, _options?: unknown): Promise<T | undefined> {
         const items = await Promise.resolve(_items);
         lastQuickPick = { items: [...items], options: _options };
-        return quickPickResponse as T | undefined;
+        const nextResponse = quickPickResponses.shift();
+        return nextResponse as T | undefined;
     },
     async showInputBox(_options?: unknown): Promise<string | undefined> {
         if (inputBoxResponses.length > 0) {
@@ -558,7 +559,7 @@ export function __setInformationMessageResponse(response: unknown): void {
 }
 
 export function __setQuickPickResponse(response: unknown): void {
-    quickPickResponse = response;
+    quickPickResponses.push(response);
 }
 
 export function __setInputBoxResponse(response: string | undefined): void {
@@ -647,7 +648,7 @@ export function __getExecutedCommands(): Array<{ command: string; args: unknown[
 export function __resetUiState(): void {
     warningResponse = undefined;
     informationResponse = undefined;
-    quickPickResponse = undefined;
+    quickPickResponses = [];
     inputBoxResponse = undefined;
     inputBoxResponses = [];
     findFilesResult = [];


### PR DESCRIPTION
## Summary
- add nested namespace selection during module apply flow so modules can be placed under existing or newly created paths under the module root
- persist recent namespace choices per workspace and reuse them in subsequent applies
- add configuration options for local module scan depth and README-weak-signal discovery
- update module manager UI strings and documentation to match the new behavior

## Testing
- npm test
- npm run check-types
- npm run lint
- npm run compile-tests